### PR TITLE
Updated validation messages and screen copy

### DIFF
--- a/integration_tests/integration/link/emailSent.spec.ts
+++ b/integration_tests/integration/link/emailSent.spec.ts
@@ -22,48 +22,11 @@ context('Link Email Sent Page', () => {
     emailSentPage.signOut().should('not.exist')
   })
 
-  it('should submit form given valid email address', () => {
+  it('should display request a link page given link to retry email is clicked', () => {
     cy.visit('/link/request-link')
     const requestLinkPage = Page.verifyOnPage(RequestLinkPage)
     const emailSentPage = requestLinkPage.submitFormWithValidEmailAddress('valid@email.address') as EmailSentPage
 
-    emailSentPage.submitFormWithValidEmailAddress('another.valid@email.address')
-
-    emailSentPage
-      .successBanner()
-      .should('exist')
-      .contains(`We've sent a link to your email - another.valid@email.address`)
-  })
-
-  it('html field validation should prevent form submission given email sent page displayed and invalid email address entered', () => {
-    cy.visit('/link/request-link')
-    const requestLinkPage = Page.verifyOnPage(RequestLinkPage)
-    const emailSentPage = requestLinkPage.submitFormWithValidEmailAddress('valid@email.address')
-
-    emailSentPage.submitFormThatFailsHtml5EmailFieldValidation('not.valid.email.address')
-
-    emailSentPage.emailFieldHasHtml5ValidationMessage(
-      "Please include an '@' in the email address. 'not.valid.email.address' is missing an '@'."
-    )
-  })
-
-  it('should redisplay request link page given email sent page displayed and attempting to resubmit form with an empty email address', () => {
-    cy.visit('/link/request-link')
-    const page = Page.verifyOnPage(RequestLinkPage)
-    const emailSentPage = page.submitFormWithValidEmailAddress('valid@email.address')
-
-    const requestLinkPage = emailSentPage.submitFormWithInvalidEmailAddress('')
-
-    requestLinkPage.errorsList().should('exist').contains('Enter an email address')
-  })
-
-  it('should redisplay request link page given email sent page displayed and attempting to resubmit form with an invalid email address', () => {
-    cy.visit('/link/request-link')
-    const page = Page.verifyOnPage(RequestLinkPage)
-    const emailSentPage = page.submitFormWithValidEmailAddress('valid@email.address')
-
-    const requestLinkPage = emailSentPage.submitFormWithInvalidEmailAddress('not.a.valid@email')
-
-    requestLinkPage.errorsList().should('exist').contains('Enter a valid email address')
+    emailSentPage.clickRequestSignInLink()
   })
 })

--- a/integration_tests/integration/link/requestLink.spec.ts
+++ b/integration_tests/integration/link/requestLink.spec.ts
@@ -25,9 +25,11 @@ context('Request Link Page', () => {
     cy.visit('/link/request-link')
     const requestLinkPage = Page.verifyOnPage(RequestLinkPage)
 
-    const emailSentPage = requestLinkPage.submitFormWithValidEmailAddress('valid@email.address') as EmailSentPage
+    const emailSentPage = requestLinkPage.submitFormWithValidEmailAddress(
+      'valid@email.address.cjsm.net'
+    ) as EmailSentPage
 
-    emailSentPage.successBanner().should('exist').contains(`We've sent a link to your email - valid@email.address`)
+    emailSentPage.successBanner().should('contain', `We've sent a link`)
   })
 
   it('html field validation should prevent form submission given invalid email address', () => {
@@ -48,7 +50,7 @@ context('Request Link Page', () => {
 
     requestLinkPage.submitFormWithInvalidEmailAddress('')
 
-    requestLinkPage.errorsList().should('exist').contains('Enter an email address')
+    requestLinkPage.errorsList().should('contain', 'email address')
   })
 
   it('should redisplay form with errors given form submitted with invalid email address', () => {
@@ -57,7 +59,17 @@ context('Request Link Page', () => {
 
     requestLinkPage.submitFormWithInvalidEmailAddress('not.a.valid@email')
 
-    requestLinkPage.errorsList().should('exist').contains('Enter a valid email address')
+    requestLinkPage.errorsList().should('contain', 'format')
+  })
+
+  it('should redisplay form with errors given form submitted with non cjsm email address', () => {
+    cy.task('stubRequestLinkNonCjsmEmailFailure')
+    cy.visit('/link/request-link')
+    const requestLinkPage = Page.verifyOnPage(RequestLinkPage)
+
+    requestLinkPage.submitFormWithInvalidEmailAddress('valid@email.address')
+
+    requestLinkPage.errorsList().should('contain', 'format')
   })
 
   it('should redisplay form with errors given send email link service fails', () => {
@@ -67,6 +79,6 @@ context('Request Link Page', () => {
 
     requestLinkPage.submitFormWithValidEmailAddress('valid@email.address', false)
 
-    requestLinkPage.errorsList().should('exist').contains('There was an error generating your sign in link')
+    requestLinkPage.errorsList().should('contain', 'request a new')
   })
 })

--- a/integration_tests/integration/link/verifyLink.spec.ts
+++ b/integration_tests/integration/link/verifyLink.spec.ts
@@ -33,19 +33,13 @@ context('Verify Link', () => {
     cy.task('stubVerifyLinkNotFoundFailure')
     cy.visit('/link/verify-link?secret=a-bogus-secret')
 
-    Page.verifyOnPage(RequestLinkPage)
-      .errorsList()
-      .should('exist')
-      .contains('There was an error verifying your email - please try again')
+    Page.verifyOnPage(RequestLinkPage).errorsList().should('contain', 'Request a new one')
   })
 
   it('should redirect to Request List page if visiting with a `secret` that returns a token with an invalid signature', () => {
     cy.task('stubVerifyLinkInvalidSignatureFailure')
     cy.visit('/link/verify-link?secret=a-valid-secret-whose-token-has-an-invalid-signature')
 
-    Page.verifyOnPage(RequestLinkPage)
-      .errorsList()
-      .should('exist')
-      .contains('There was an error verifying your email - please try again')
+    Page.verifyOnPage(RequestLinkPage).errorsList().should('contain', 'Request a new one')
   })
 })

--- a/integration_tests/mockApis/sendLegalMail.ts
+++ b/integration_tests/mockApis/sendLegalMail.ts
@@ -31,6 +31,26 @@ const stubRequestLinkFailure = (): SuperAgentRequest =>
     },
   })
 
+const stubRequestLinkNonCjsmEmailFailure = (): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPattern: '/send-legal-mail/link/email',
+      bodyPatterns: [{ matchesJsonPath: '$[?(@.email =~ /.*/i)]' }],
+    },
+    response: {
+      status: 400,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: {
+        status: 400,
+        errorCode: 'INVALID_CJSM_EMAIL',
+        userMessage: `Enter an email address which ends with 'cjsm.net'`,
+      },
+    },
+  })
+
 const stubVerifyLink = (): SuperAgentRequest =>
   stubFor({
     request: {
@@ -87,6 +107,7 @@ const stubVerifyLinkNotFoundFailure = (): SuperAgentRequest =>
 export default {
   stubRequestLink,
   stubRequestLinkFailure,
+  stubRequestLinkNonCjsmEmailFailure,
   stubVerifyLink,
   stubVerifyLinkNotFoundFailure,
   stubVerifyLinkInvalidSignatureFailure,

--- a/integration_tests/pages/link/emailSent.ts
+++ b/integration_tests/pages/link/emailSent.ts
@@ -7,41 +7,11 @@ export default class EmailSentPage extends Page {
     super('Now check your emails')
   }
 
-  submitFormWithValidEmailAddress = (email: string): EmailSentPage => {
-    this.emailField().type(email)
+  clickRequestSignInLink = (): RequestLinkPage => {
+    cy.get('a[data-qa="request-sign-in-link"]').click()
 
-    this.submitButton().click()
-    return Page.verifyOnPage(EmailSentPage)
-  }
-
-  submitFormWithInvalidEmailAddress = (email: string): RequestLinkPage => {
-    if (!!email && email.length > 0) {
-      this.emailField().type(email)
-    } else {
-      this.emailField().clear()
-    }
-
-    this.submitButton().click()
     return Page.verifyOnPage(RequestLinkPage)
   }
-
-  submitFormThatFailsHtml5EmailFieldValidation = (email: string): EmailSentPage => {
-    this.emailField().type(email)
-
-    this.submitButton().click()
-    return Page.verifyOnPage(EmailSentPage)
-  }
-
-  emailFieldHasHtml5ValidationMessage = (message: string): EmailSentPage => {
-    this.emailField().then($input => {
-      expect(($input[0] as HTMLInputElement).validationMessage).to.eq(message)
-    })
-    return Page.verifyOnPage(EmailSentPage)
-  }
-
-  emailField = (): PageElement => cy.get('#email')
-
-  submitButton = (): PageElement => cy.get('button[data-qa="request-link-button"]')
 
   successBanner = (): PageElement => cy.get('div.govuk-notification-banner--success')
 }

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -19,6 +19,7 @@ export default (on: (string, Record) => void): void => {
 
     stubRequestLink: sendLegalMail.stubRequestLink,
     stubRequestLinkFailure: sendLegalMail.stubRequestLinkFailure,
+    stubRequestLinkNonCjsmEmailFailure: sendLegalMail.stubRequestLinkNonCjsmEmailFailure,
     stubVerifyLink: sendLegalMail.stubVerifyLink,
     stubVerifyLinkNotFoundFailure: sendLegalMail.stubVerifyLinkNotFoundFailure,
     stubVerifyLinkInvalidSignatureFailure: sendLegalMail.stubVerifyLinkInvalidSignatureFailure,

--- a/server/config.ts
+++ b/server/config.ts
@@ -85,4 +85,5 @@ export default {
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   gtmContainerId: get('GOOGLE_TAG_MANAGER_CONTAINER_ID', null),
+  magicLinkValidityDuration: Number(get('MAGIC_LINK_VALIDITY_DURATION_IN_MINUTES', 10)),
 }

--- a/server/middleware/barcode/barcodeAuthorisationMiddleware.ts
+++ b/server/middleware/barcode/barcodeAuthorisationMiddleware.ts
@@ -18,7 +18,7 @@ export default function barcodeAuthorisationMiddleware(): RequestHandler {
       { algorithms: ['RS256'] },
       (err: VerifyErrors, payload: JwtPayload) => {
         if (err) {
-          req.flash('errors', [{ text: 'There was an error verifying your email - please try again' }])
+          req.flash('errors', [{ text: 'The link you used is no longer valid. Request a new one to log in.' }])
           return res.redirect('/link/request-link')
         }
         req.session.barcodeUserEmail = payload.sub

--- a/server/routes/link/RequestLinkController.ts
+++ b/server/routes/link/RequestLinkController.ts
@@ -28,8 +28,12 @@ export default class RequestLinkController {
         const view = new RequestLinkView({}, [])
         return res.render('pages/link/emailSent', { ...view.renderArgs, emailSentTo })
       })
-      .catch(() => {
-        req.flash('errors', [{ text: 'There was an error generating your sign in link' }])
+      .catch(error => {
+        const errorMessage =
+          error.status === 400 && error.data.errorCode === 'INVALID_CJSM_EMAIL'
+            ? 'Enter an email address in the correct format'
+            : 'There was an error generating your sign in link. Try again to request a new one to log in.'
+        req.flash('errors', [{ text: errorMessage }])
         return res.redirect('request-link')
       })
   }

--- a/server/routes/link/RequestLinkValidator.test.ts
+++ b/server/routes/link/RequestLinkValidator.test.ts
@@ -26,7 +26,9 @@ describe('RequestLinkValidator', () => {
       const valid = validate(form, req)
 
       expect(valid).toBe(false)
-      expect(req.flash).toHaveBeenCalledWith('errors', [{ href: '#email', text: 'Enter a valid email address' }])
+      expect(req.flash).toHaveBeenCalledWith('errors', [
+        { href: '#email', text: 'Enter an email address in the correct format' },
+      ])
     })
 
     it('should not validate given empty form', async () => {
@@ -34,7 +36,9 @@ describe('RequestLinkValidator', () => {
       const valid = validate(form, req)
 
       expect(valid).toBe(false)
-      expect(req.flash).toHaveBeenCalledWith('errors', [{ href: '#email', text: 'Enter an email address' }])
+      expect(req.flash).toHaveBeenCalledWith('errors', [
+        { href: '#email', text: 'Enter an email address in the correct format' },
+      ])
     })
   })
 })

--- a/server/routes/link/RequestLinkValidator.ts
+++ b/server/routes/link/RequestLinkValidator.ts
@@ -5,9 +5,9 @@ export default function validate(form: RequestLinkForm, req: Request): boolean {
   const errors: Array<Record<string, string>> = []
 
   if (!form.email) {
-    errors.push({ href: '#email', text: 'Enter an email address' })
+    errors.push({ href: '#email', text: 'Enter your CJSM email address' })
   } else if (!validateEmail(form.email)) {
-    errors.push({ href: '#email', text: 'Enter a valid email address' })
+    errors.push({ href: '#email', text: 'Enter an email address in the correct format' })
   }
 
   if (errors.length > 0) {

--- a/server/routes/link/RequestLinkView.ts
+++ b/server/routes/link/RequestLinkView.ts
@@ -1,4 +1,5 @@
 import type { RequestLinkForm } from 'forms'
+import config from '../../config'
 
 export default class RequestLinkView {
   constructor(
@@ -6,8 +7,13 @@ export default class RequestLinkView {
     private readonly errors?: Array<Record<string, string>>
   ) {}
 
-  get renderArgs(): { form: RequestLinkForm; errors: Array<Record<string, string>> } {
+  get renderArgs(): {
+    magicLinkValidityDuration: number
+    form: RequestLinkForm
+    errors: Array<Record<string, string>>
+  } {
     return {
+      magicLinkValidityDuration: config.magicLinkValidityDuration,
       form: this.requestLinkForm,
       errors: this.errors || [],
     }

--- a/server/routes/link/VerifyLinkController.ts
+++ b/server/routes/link/VerifyLinkController.ts
@@ -17,7 +17,7 @@ export default class VerifyLinkController {
         return res.redirect('/barcode/find-recipient')
       })
       .catch(() => {
-        req.flash('errors', [{ text: 'There was an error verifying your email - please try again' }])
+        req.flash('errors', [{ text: 'The link you used is no longer valid. Request a new one to log in.' }])
         return res.redirect('request-link')
       })
   }

--- a/server/views/pages/link/emailSent.njk
+++ b/server/views/pages/link/emailSent.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
-{% set pageTitle = applicationName + " - Request a link" %}
+{% set pageTitle = applicationName + " - Sign in link email sent" %}
 {% set pageId = 'email-sent' %}
 
 {% block content %}
@@ -35,44 +35,17 @@
       <div class="govuk-grid-column-full">
         <h3>What to do if you don't get the link</h3>
         <p>Check that the:
-          <ul class="govuk-list">
+          <ul class="govuk-list govuk-list--bullet">
             <li>email address you've entered is correct - it needs to be valid for the Criminal Justice Secure Mail (CJSM) service</li>
             <li>link hasn't gone to your 'spam' or 'junk' folder
           </ul>
         </p>
+
+        <p>
+            <a href="request-link" class="govuk-link" data-qa="request-sign-in-link">Enter your email again</a>
+        </p>
       </div>
     </div>
-
-	<div class="govuk-grid-row">
-	  <div class="govuk-grid-column-two-thirds">
-		<form id="email-form" action="request-link" method="post">
-		  <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-
-		  {% call govukFieldset({ }) %}
-			{{ govukInput({
-			  label: {
-				text: 'Resubmit your CJSM or other approved email address'
-			  },
-			  hint: {
-				text: 'Enter your CJSM email'
-			  },
-			  id: "email",
-			  name: "email",
-			  value: form.email,
-			  type: 'email',
-			  errorMessage: errors | findError('email')
-			}) }}
-			<div class="govuk-button-group">
-			  {{ govukButton({
-				text: "Submit",
-				attributes: { 'data-qa': 'request-link-button' }
-			  }) }}
-			</div>
-		  {% endcall %}
-
-		</form>
-	  </div>
-	</div>
   </main>
 
 {% endblock %}

--- a/server/views/pages/link/requestLink.njk
+++ b/server/views/pages/link/requestLink.njk
@@ -21,9 +21,9 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <h1 class="govuk-heading-xl">Request a link to log in</h1>
-        <p>Enter your Criminal Justice Secure Mail (CJSM) email address. Your organisational email address may be approved for use with CJSM.</p>
-        <p>You'll receive an email containing a link to the sercice in your inbox. Follow the link to log in.</p>
-        <p>The link will expire 10 minutes after you request it.</p>
+        <h2 class="govuk-heading-s">Enter your Criminal Justice Secure Mail (CJSM) email address.</h2>
+        <p>You'll receive an email containing a link to the service in your inbox. Follow the link to log in.</p>
+        <p>The link will expire {{ magicLinkValidityDuration }} minutes after you request it.</p>
       </div>
     </div>
 
@@ -35,7 +35,7 @@
           {% call govukFieldset({ }) %}
             {{ govukInput({
               label: {
-                text: 'Enter your CJSM email'
+                text: 'Enter your CJSM email, for example name@myorganisation.com.cjsm.net'
               },
               id: "email",
               name: "email",


### PR DESCRIPTION
This PR updates the screen copy and validation messages for the Request A Link page and Email Sent page, based on the latest copy from the design team.

Things of note:
* The Email Sent page has changed in that it no longer has a field to allow retrying to send the email, and instead has a link to take you back to the Request A Link page. Therefore the integration tests and associated Page class have changed quite a bit.
* The assertions in the integration tests re: error messaging have been simplified and made more generic, testing more that an error message is present rather than the specifics of the precise wording of the error message (ie. they were fragile before)
* Added error handling from the API when the supplied email address is not a CJSM email, and added an integration test for this scenario
* Added the magic link validity duration as a configuration parameter so as not to hard code it in the view (the design team are currently flip-flopping between 10 and 60 mins!) (see `config.ts`)