### PR TITLE
SLM remove allow list

### DIFF
--- a/helm_deploy/send-legal-mail-to-prisons/values.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons/values.yaml
@@ -47,16 +47,5 @@ generic-service:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"
 
-  allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    moj-global-protect: "35.176.93.186/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    ark-internet-1: "194.33.192.0/25"
-    ark-internet-2: "194.33.196.0/25"
-
 generic-prometheus-alerts:
   targetApplication: send-legal-mail-to-prisons

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,7 @@ generic-service:
     INGRESS_URL: "https://send-legal-mail-preprod.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
+    SEND_LEGAL_MAIL_API_URL: "https://send-legal-mail-api-preprod.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
We're having issues with team members being blocked with 403s. I don't understand how the mesh of MOJ networks hangs together but we keep finding new and exciting ways to be blocked. The UI will be public anyway so just turning off the allow list completely.