### PR TITLE
SLM-8: Track 'report barcode entry problem' event via AppInsights

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -3,14 +3,16 @@
  * Do appinsights first as it does some magic instrumentation work, i.e. it affects other 'require's
  * In particular, applicationinsights automatically collects bunyan logs
  */
+import { TelemetryClient } from 'applicationinsights'
 import { initialiseAppInsights, buildAppInsightsClient } from './server/utils/azureAppInsights'
 
 initialiseAppInsights()
-buildAppInsightsClient()
+const appInsightsTelemetryClient: TelemetryClient = buildAppInsightsClient()
 
 import app from './server/index'
 import logger from './logger'
 
-app.listen(app.get('port'), () => {
-  logger.info(`Server listening on port ${app.get('port')}`)
+const application = app(appInsightsTelemetryClient)
+application.listen(application.get('port'), () => {
+  logger.info(`Server listening on port ${application.get('port')}`)
 })

--- a/server/app.ts
+++ b/server/app.ts
@@ -26,12 +26,14 @@ import setupLinkEmailSent from './middleware/link/setupLinkEmailSent'
 import requestLinkAuthorised from './middleware/link/requestLinkAuthorised'
 import ScanBarcodeService from './services/scan/ScanBarcodeService'
 import CreateBarcodeService from './services/barcode/CreateBarcodeService'
+import AppInsightsService from './services/AppInsightsService'
 
 export default function createApp(
   userService: UserService,
   magicLinkService: MagicLinkService,
   scanBarcodeService: ScanBarcodeService,
-  createBarcodeService: CreateBarcodeService
+  createBarcodeService: CreateBarcodeService,
+  appInsightsClient: AppInsightsService
 ): express.Application {
   const app = express()
 
@@ -62,7 +64,7 @@ export default function createApp(
   app.use('/', indexRoutes(standardRouter(userService)))
   app.use('/', authorisationMiddleware(['ROLE_SLM_SCAN_BARCODE', 'ROLE_SLM_SECURITY_ANALYST']))
 
-  app.use('/', setupScanBarcode(scanBarcodeService))
+  app.use('/', setupScanBarcode(scanBarcodeService, appInsightsClient))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(process.env.NODE_ENV === 'production'))

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,5 @@
+import express from 'express'
+import { TelemetryClient } from 'applicationinsights'
 import createApp from './app'
 import HmppsAuthClient from './data/hmppsAuthClient'
 import UserService from './services/userService'
@@ -5,13 +7,17 @@ import TokenStore from './data/tokenStore'
 import MagicLinkService from './services/link/MagicLinkService'
 import ScanBarcodeService from './services/scan/ScanBarcodeService'
 import CreateBarcodeService from './services/barcode/CreateBarcodeService'
+import AppInsightsService from './services/AppInsightsService'
 
-const hmppsAuthClient = new HmppsAuthClient(new TokenStore())
-const userService = new UserService(hmppsAuthClient)
-const magicLinkService = new MagicLinkService(hmppsAuthClient)
-const scanBarcodeService = new ScanBarcodeService(hmppsAuthClient)
-const createBarcodeService = new CreateBarcodeService()
+const app = (appInsightsTelemetryClient?: TelemetryClient): express.Application => {
+  const hmppsAuthClient = new HmppsAuthClient(new TokenStore())
+  const userService = new UserService(hmppsAuthClient)
+  const magicLinkService = new MagicLinkService(hmppsAuthClient)
+  const scanBarcodeService = new ScanBarcodeService(hmppsAuthClient)
+  const createBarcodeService = new CreateBarcodeService()
+  const appInsightsService = new AppInsightsService(appInsightsTelemetryClient)
 
-const app = createApp(userService, magicLinkService, scanBarcodeService, createBarcodeService)
+  return createApp(userService, magicLinkService, scanBarcodeService, createBarcodeService, appInsightsService)
+}
 
 export default app

--- a/server/middleware/scan/setupScanBarcode.ts
+++ b/server/middleware/scan/setupScanBarcode.ts
@@ -2,11 +2,15 @@ import express, { Router } from 'express'
 import authorisationMiddleware from '../authorisationMiddleware'
 import ScanBarcodeController from '../../routes/scan/ScanBarcodeController'
 import ScanBarcodeService from '../../services/scan/ScanBarcodeService'
+import AppInsightsService from '../../services/AppInsightsService'
 
-export default function setupScanBarcode(scanBarcodeService: ScanBarcodeService): Router {
+export default function setupScanBarcode(
+  scanBarcodeService: ScanBarcodeService,
+  appInsightsClient: AppInsightsService
+): Router {
   const router = express.Router()
 
-  const scanBarcodeController = new ScanBarcodeController(scanBarcodeService)
+  const scanBarcodeController = new ScanBarcodeController(scanBarcodeService, appInsightsClient)
 
   router.use('/scan-barcode', authorisationMiddleware(['ROLE_SLM_SCAN_BARCODE']))
   router.get('/scan-barcode', (req, res) => scanBarcodeController.getScanBarcodeView(req, res))

--- a/server/routes/scan/ScanBarcodeController.ts
+++ b/server/routes/scan/ScanBarcodeController.ts
@@ -62,7 +62,7 @@ export default class ScanBarcodeController {
   /* ************************************************************** */
 
   async getBarcodeScanProblemView(req: Request, res: Response): Promise<void> {
-    this.appInsightsClient.trackMetric('cannotEnterBarcode')
+    this.appInsightsClient.trackEvent('cannotEnterBarcode')
 
     req.session.barcodeEntryForm = { ...req.body }
     req.session.barcodeEntryForm.errorCode = { code: 'CANNOT_ENTER_BARCODE' }

--- a/server/services/AppInsightsService.ts
+++ b/server/services/AppInsightsService.ts
@@ -1,10 +1,9 @@
 import { TelemetryClient } from 'applicationinsights'
-import { performance } from 'perf_hooks'
 
 export default class AppInsightsService {
   constructor(private readonly appInsightsTelemetryClient?: TelemetryClient) {}
 
-  trackMetric = (metric: string): void => {
-    this.appInsightsTelemetryClient?.trackMetric({ name: metric, value: performance.now() })
+  trackEvent = (event: string): void => {
+    this.appInsightsTelemetryClient?.trackEvent({ name: event })
   }
 }

--- a/server/services/AppInsightsService.ts
+++ b/server/services/AppInsightsService.ts
@@ -1,0 +1,10 @@
+import { TelemetryClient } from 'applicationinsights'
+import { performance } from 'perf_hooks'
+
+export default class AppInsightsService {
+  constructor(private readonly appInsightsTelemetryClient?: TelemetryClient) {}
+
+  trackMetric = (metric: string): void => {
+    this.appInsightsTelemetryClient?.trackMetric({ name: metric, value: performance.now() })
+  }
+}


### PR DESCRIPTION
Refactored the way the express `app` is created so that the appInsights `TelemetryClient` can be created once (before the app) and injected into the app