### PR TITLE
SLM-70: Fixed 404s on result page; added e2e journey test

### DIFF
--- a/integration_tests/integration/e2e/mailroomJourneyE2e.spec.ts
+++ b/integration_tests/integration/e2e/mailroomJourneyE2e.spec.ts
@@ -1,0 +1,62 @@
+import Page from '../../pages/page'
+import ScanBarcodePage from '../../pages/scan/scanBarcode'
+import ScanBarcodeResultPage from '../../pages/scan/scanBarcodeResult'
+
+context('Mailroom Journey E2E', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubAuthUser')
+    cy.task('stubSignInWithRole_SLM_SCAN_BARCODE')
+    cy.task('stubVerifyValidBarcode')
+    cy.task('stubVerifyNotFoundBarcode')
+    cy.task('stubVerifyRandomCheckBarcode')
+  })
+
+  it('should allow mailroom staff to perform all actions as part of their workflow', () => {
+    // Sign in and navigate to the Scan Barcode Page
+    cy.signIn()
+    cy.visit('/scan-barcode')
+    const scanBarcodePage = Page.verifyOnPage(ScanBarcodePage)
+
+    // Scan a valid barcode and arrive on the results page
+    let resultPage: ScanBarcodeResultPage = scanBarcodePage.submitFormWithValidBarcode()
+    resultPage.hasMainHeading('Ready for final delivery')
+
+    // From the result page, scan another valid barcode
+    resultPage.submitFormWithValidBarcode()
+    resultPage.hasMainHeading('Ready for final delivery')
+
+    // Click the Further Checks link and arrive on the results page with appropriate content
+    resultPage.clickFurtherChecksNecessary()
+    resultPage.hasMainHeading('Carry out further checks')
+
+    // From the result page, scan another valid barcode
+    resultPage.submitFormWithValidBarcode()
+    resultPage.hasMainHeading('Ready for final delivery')
+
+    // Scan a barcode that is not recognised
+    resultPage.submitFormWithBarcodeThatDoesNotExist()
+    resultPage.hasMainHeading('Carry out further checks')
+
+    // Go to the manual barcode entry page to try entering if from there
+    let manualBarcodeEntryPage = resultPage.clickToGoToManualBarcodeEntryPage()
+    resultPage = manualBarcodeEntryPage.submitFormWithBarcodeThatDoesNotExist()
+    resultPage.hasMainHeading('Carry out further checks')
+
+    // Go back to the manual barcode entry page and click the link that says we have a problem entering a barcode
+    manualBarcodeEntryPage = resultPage.clickToGoToManualBarcodeEntryPage()
+    resultPage = manualBarcodeEntryPage.problemEnteringBarcode()
+    resultPage.hasMainHeading('Carry out further checks')
+
+    // From the result page, scan another valid barcode
+    resultPage.submitFormWithValidBarcode()
+    resultPage.hasMainHeading('Ready for final delivery')
+
+    // Scan a barcode that will result in a random check
+    resultPage.submitFormWithBarcodeThatWillBeSelectedForARandomCheck()
+    resultPage.hasMainHeading('Item selected for a random check')
+
+    // Sign Out having done a good day's work
+    resultPage.signOut()
+  })
+})

--- a/integration_tests/pages/scan/manualBarcodeEntry.ts
+++ b/integration_tests/pages/scan/manualBarcodeEntry.ts
@@ -1,4 +1,5 @@
 import Page, { PageElement } from '../page'
+// eslint-disable-next-line import/no-cycle
 import ScanBarcodeResultPage from './scanBarcodeResult'
 import barcodes from '../../mockApis/barcodes'
 

--- a/integration_tests/pages/scan/scanBarcodeResult.ts
+++ b/integration_tests/pages/scan/scanBarcodeResult.ts
@@ -1,4 +1,7 @@
 import Page, { PageElement } from '../page'
+// eslint-disable-next-line import/no-cycle
+import ManualBarcodeEntryPage from './manualBarcodeEntry'
+import barcodes from '../../mockApis/barcodes'
 
 export default class ScanBarcodeResultPage extends Page {
   constructor() {
@@ -15,7 +18,63 @@ export default class ScanBarcodeResultPage extends Page {
     return Page.verifyOnPage(ScanBarcodeResultPage)
   }
 
+  clickToGoToManualBarcodeEntryPage = (): ManualBarcodeEntryPage => {
+    this.manualBarcodeEntryLink().click()
+    return Page.verifyOnPage(ManualBarcodeEntryPage)
+  }
+
+  setBarcode = (value: string): ScanBarcodeResultPage => {
+    if (value && value.length > 0) {
+      this.barcode().type(value)
+    } else {
+      this.barcode().clear()
+    }
+    return Page.verifyOnPage(ScanBarcodeResultPage)
+  }
+
+  pressEnterInBarcodeField = () => {
+    this.barcode().type('\n')
+  }
+
+  submitFormWithBarcodeThatFailsValidation = (): ScanBarcodeResultPage => {
+    this.setBarcode(barcodes.INVALID_FORMAT_BARCODE)
+    this.pressEnterInBarcodeField()
+    return Page.verifyOnPage(ScanBarcodeResultPage)
+  }
+
+  submitFormWithValidBarcode = (): ScanBarcodeResultPage => {
+    this.setBarcode(barcodes.VALID_BARCODE)
+    this.pressEnterInBarcodeField()
+    return Page.verifyOnPage(ScanBarcodeResultPage)
+  }
+
+  submitFormWithBarcodeThatHasBeenScannedPreviously = (): ScanBarcodeResultPage => {
+    this.setBarcode(barcodes.PREVIOUSLY_SCANNED_BARCODE)
+    this.pressEnterInBarcodeField()
+    return Page.verifyOnPage(ScanBarcodeResultPage)
+  }
+
+  submitFormWithBarcodeThatWillBeSelectedForARandomCheck = (): ScanBarcodeResultPage => {
+    this.setBarcode(barcodes.BARCODE_SELECTED_FOR_RANDOM_CHECK)
+    this.pressEnterInBarcodeField()
+    return Page.verifyOnPage(ScanBarcodeResultPage)
+  }
+
+  submitFormWithBarcodeThatHasExpired = (): ScanBarcodeResultPage => {
+    this.setBarcode(barcodes.EXPIRED_BARCODE)
+    this.pressEnterInBarcodeField()
+    return Page.verifyOnPage(ScanBarcodeResultPage)
+  }
+
+  submitFormWithBarcodeThatDoesNotExist = (): ScanBarcodeResultPage => {
+    this.setBarcode(barcodes.UNRECOGNISED_BARCODE)
+    this.pressEnterInBarcodeField()
+    return Page.verifyOnPage(ScanBarcodeResultPage)
+  }
+
   barcode = (): PageElement => cy.get('#barcode')
 
   furtherChecksNecessaryLink = (): PageElement => cy.get('#further-checks')
+
+  manualBarcodeEntryLink = (): PageElement => cy.get('#manual-barcode-entry')
 }

--- a/server/views/pages/scan/manual-barcode-entry.njk
+++ b/server/views/pages/scan/manual-barcode-entry.njk
@@ -22,7 +22,7 @@
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">Enter the barcode number manually</h1>
 
-        <form action="manually-enter-barcode" method="post" novalidate>
+        <form action="/manually-enter-barcode" method="post" novalidate>
           <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
           {% call govukFieldset() %}

--- a/server/views/pages/scan/scan-barcode-result.njk
+++ b/server/views/pages/scan/scan-barcode-result.njk
@@ -45,7 +45,7 @@
         <h2 class="govuk-heading-l">Scan another barcode</h2>
         <img src="/assets/images/barcode-scanner.png" title="A barcode scanner being used to scan a barcode from an item of mail" />
 
-        <form action="scan-barcode" method="post" novalidate>
+        <form action="/scan-barcode" method="post" novalidate>
           <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
           {% call govukFieldset() %}
@@ -83,7 +83,7 @@
       <div class="govuk-grid-column-full">
         <h3 class="govuk-heading-m">What to do if the scan doesn't work</h3>
         <p>If the barcode won't scan, enter the barcode number manually instead.</p>
-        <a href="/manually-enter-barcode" class="govuk-link" id="manual-scan">I can't scan the barcode</a>
+        <a href="/manually-enter-barcode" class="govuk-link" id="manual-barcode-entry">I can't scan the barcode</a>
       </div>
     </div>
 

--- a/server/views/pages/scan/scan-barcode.njk
+++ b/server/views/pages/scan/scan-barcode.njk
@@ -50,7 +50,7 @@
         <h2 class="govuk-heading-l">Scan the barcode on the mail</h2>
         <img src="/assets/images/barcode-scanner.png" title="A barcode scanner being used to scan a barcode from an item of mail" />
 
-        <form action="scan-barcode" method="post" novalidate>
+        <form action="/scan-barcode" method="post" novalidate>
           <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
           {% call govukFieldset() %}


### PR DESCRIPTION
The fix for the 404s was to add a slash/root prefix on the action url of the 'scan again' forms