### PR TITLE
SLM-72 generate barcode image

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The app requires:
 
 To start the main services excluding the example typescript template app: 
 
-`docker-compose up --scale app=0`
+`docker-compose up redis hmpps-auth nomins-user-roles-api`
 
 Install dependencies using `npm install`, ensuring you are using >= `Node v14.x`
 
@@ -76,7 +76,10 @@ TOKEN_VERIFICATION_ENABLED=false
 NODE_ENV=development
 SESSION_SECRET=anything
 PORT=3000
+SEND_LEGAL_MAIL_API_URL=http://localhost:8080
+PRISON_REGISTER_API_URL=https://prison-register-dev.hmpps.service.justice.gov.uk
 ```
+TODO - when we start using the prison register in Docker compose `PRISON_REGISTER_API_URL` should point to localhost on the correct port.
 
 And then, to build the assets and start the app with nodemon:
 
@@ -87,6 +90,16 @@ And then, to build the assets and start the app with nodemon:
 This app needs the `send-legal-mail-to-prisons-api` project too which provides the back end for the front end.
 
 See the [API Readme](https://github.com/ministryofjustice/send-legal-mail-to-prisons-api#running-the-app-for-development---gradle) for instructions to run the API for development too.
+
+#### How do I sign is as a legal mail sender?
+
+Visit URL `http://localhost:3000/barcode/find-recipient` which should redirect to the `Request a link to sign in` page. Enter any email address that ends with `cjsm.net`.
+
+Open mailcatcher at `http://localhost:1080`. Open the first email which should contain a link - click on the link and you will be signed in.
+
+#### How do I sign in as a mailroom staff user?
+
+Visit URL `http://localhost:3000` which should redirect you to the HMPPS Auth sign in page. Enter credentials `SLM_MAILROOM_USER_LOCAL` / `password1234556`.
 
 ### Run linter
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "body-parser": "^1.19.0",
         "bunyan": "^1.8.15",
         "bunyan-format": "^0.2.1",
+        "bwip-js": "^3.0.4",
         "compression": "^1.7.4",
         "connect-flash": "^0.1.1",
         "connect-redis": "^6.0.0",
@@ -4150,6 +4151,14 @@
         "ansicolors": "~0.2.1",
         "ansistyles": "~0.1.1",
         "xtend": "~2.1.1"
+      }
+    },
+    "node_modules/bwip-js": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/bwip-js/-/bwip-js-3.0.4.tgz",
+      "integrity": "sha512-Gx1NYJsrAs99Ry5OQNPtbwwT7dw9kAhJDneiw1imfMmxEb9GHYl+7VeBxMZTFLgew8eLadfHPqUui5HhTYb6fw==",
+      "bin": {
+        "bwip-js": "bin/bwip-js.js"
       }
     },
     "node_modules/bytes": {
@@ -16277,6 +16286,11 @@
         "ansistyles": "~0.1.1",
         "xtend": "~2.1.1"
       }
+    },
+    "bwip-js": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/bwip-js/-/bwip-js-3.0.4.tgz",
+      "integrity": "sha512-Gx1NYJsrAs99Ry5OQNPtbwwT7dw9kAhJDneiw1imfMmxEb9GHYl+7VeBxMZTFLgew8eLadfHPqUui5HhTYb6fw=="
     },
     "bytes": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "body-parser": "^1.19.0",
     "bunyan": "^1.8.15",
     "bunyan-format": "^0.2.1",
+    "bwip-js": "^3.0.4",
     "compression": "^1.7.4",
     "connect-flash": "^0.1.1",
     "connect-redis": "^6.0.0",

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -14,6 +14,7 @@ declare module 'express-session' {
     findRecipientForm: FindRecipientForm
     barcodeEntryForm: BarcodeEntryForm
     barcode: string
+    barcodeImageUrl: string
   }
 }
 

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -31,6 +31,7 @@ export default function setUpWebSecurity(): Router {
           connectSrc: ["'self'", 'www.googletagmanager.com', 'www.google-analytics.com'],
           styleSrc: ["'self'", 'code.jquery.com'],
           fontSrc: ["'self'"],
+          imgSrc: ["'self'", 'data:'],
         },
       },
     })

--- a/server/routes/barcode/CreateBarcodeController.ts
+++ b/server/routes/barcode/CreateBarcodeController.ts
@@ -1,4 +1,8 @@
 import { Request, Response } from 'express'
+// TODO we cannot import the types for this because alttext should be a string but is typed as a boolean. See fix at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57999. When fixed run command `npm install @types/bwip-js --save-dev` and remove these comments.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import bwipjs from 'bwip-js'
 import CreateBarcodeService from '../../services/barcode/CreateBarcodeService'
 
 export default class CreateBarcodeController {
@@ -6,8 +10,19 @@ export default class CreateBarcodeController {
 
   async submitCreateBarcode(req: Request, res: Response): Promise<void> {
     return this.createBarcodeService.createBarcode(req.session.createBarcodeAuthToken).then(barcode => {
-      req.session.barcode = barcode
-      return res.redirect('/barcode/find-recipient')
+      bwipjs
+        .toBuffer({
+          bcid: 'code128',
+          text: barcode,
+          alttext: `${barcode.substring(0, 4)}-${barcode.substring(4, 8)}-${barcode.substring(8, 12)}`,
+          includetext: true,
+          textxalign: 'center',
+        })
+        .then((barcodeBuffer: Buffer) => {
+          req.session.barcodeImageUrl = `data:image/png;base64,${barcodeBuffer.toString('base64')}`
+          req.session.barcode = barcode
+          return res.redirect('/barcode/find-recipient')
+        })
     })
   }
 }

--- a/server/routes/barcode/FindRecipientController.ts
+++ b/server/routes/barcode/FindRecipientController.ts
@@ -11,6 +11,7 @@ export default class FindRecipientController {
         req.session?.findRecipientForm || {},
         req.flash('errors'),
         req.session.barcode,
+        req.session.barcodeImageUrl,
         activePrisons
       )
       return res.render('pages/barcode/find-recipient', { ...view.renderArgs })

--- a/server/routes/barcode/FindRecipientView.ts
+++ b/server/routes/barcode/FindRecipientView.ts
@@ -6,6 +6,7 @@ export default class FindRecipientView {
     private readonly findRecipientForm: FindRecipientForm,
     private readonly errors?: Array<Record<string, string>>,
     private readonly barcode?: string,
+    private readonly barcodeImageUrl?: string,
     private readonly prisonRegister?: Array<Prison>
   ) {}
 
@@ -13,12 +14,14 @@ export default class FindRecipientView {
     form: FindRecipientForm
     errors: Array<Record<string, string>>
     barcode: string
+    barcodeImageUrl: string
     prisonRegister: Array<Record<string, string>>
   } {
     return {
       form: this.findRecipientForm,
       errors: this.errors || [],
       barcode: this.barcode,
+      barcodeImageUrl: this.barcodeImageUrl,
       prisonRegister: this.prisonRegister.map(prison => {
         return {
           value: prison.id,

--- a/server/views/pages/barcode/find-recipient.njk
+++ b/server/views/pages/barcode/find-recipient.njk
@@ -30,6 +30,11 @@
 
         {% if barcode %}
           <p>Barcode number: {{ barcode }}</p>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <img src="{{ barcodeImageUrl }}" id="barcodeImage" style="display: block">
+            </div>
+          </div>
         {% else %}
           <p>Press the button to generate a barcode</p>
         {% endif %}

--- a/server/views/pages/barcode/find-recipient.njk
+++ b/server/views/pages/barcode/find-recipient.njk
@@ -32,7 +32,7 @@
           <p>Barcode number: {{ barcode }}</p>
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-              <img src="{{ barcodeImageUrl }}" id="barcodeImage" style="display: block">
+              <img alt="The generated barcode image" src="{{ barcodeImageUrl }}" id="barcodeImage" style="display: block">
             </div>
           </div>
         {% else %}


### PR DESCRIPTION
Shows the barcode on screen when you generate a new barcode from the legal mail sender sign in.

This barcode will be removed from the screen and added to the printed documents in future stories.

![image](https://user-images.githubusercontent.com/58170926/148389220-be02e832-956c-40bd-9dc7-324d36230b52.png)
