### PR TITLE
SLM-73: Use the PrisonRegisterStore to cache active prisons in PrisonRegisterService

### DIFF
--- a/server/@types/prisonTypes.ts
+++ b/server/@types/prisonTypes.ts
@@ -1,4 +1,4 @@
-export interface Prison {
+export type Prison = {
   id: string
   name: string
 }

--- a/server/data/cache/PrisonRegisterStore.test.ts
+++ b/server/data/cache/PrisonRegisterStore.test.ts
@@ -1,6 +1,6 @@
 import { RedisClient } from 'redis'
 import PrisonRegisterStore from './PrisonRegisterStore'
-import { Prison } from '../../services/prison/PrisonTypes'
+import { Prison } from '../../@types/prisonTypes'
 
 const redisClient = {
   on: jest.fn(),

--- a/server/data/cache/PrisonRegisterStore.ts
+++ b/server/data/cache/PrisonRegisterStore.ts
@@ -1,7 +1,7 @@
 import redis from 'redis'
 import createRedisClient from './createRedisClient'
 import RedisStore from './RedisStore'
-import { Prison } from '../../services/prison/PrisonTypes'
+import { Prison } from '../../@types/prisonTypes'
 
 const ACTIVE_PRISONS = 'activePrisons'
 

--- a/server/data/cache/PrisonRegisterStore.ts
+++ b/server/data/cache/PrisonRegisterStore.ts
@@ -1,7 +1,7 @@
 import redis from 'redis'
 import createRedisClient from './createRedisClient'
 import RedisStore from './RedisStore'
-import { Prison } from '../../services/prison/PrisonRegisterService'
+import { Prison } from '../../services/prison/PrisonTypes'
 
 const ACTIVE_PRISONS = 'activePrisons'
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import ScanBarcodeService from './services/scan/ScanBarcodeService'
 import CreateBarcodeService from './services/barcode/CreateBarcodeService'
 import AppInsightsService from './services/AppInsightsService'
 import PrisonRegisterService from './services/prison/PrisonRegisterService'
+import PrisonRegisterStore from './data/cache/PrisonRegisterStore'
 
 const app = (appInsightsTelemetryClient?: TelemetryClient): express.Application => {
   const hmppsAuthClient = new HmppsAuthClient(new TokenStore())
@@ -16,7 +17,7 @@ const app = (appInsightsTelemetryClient?: TelemetryClient): express.Application 
   const magicLinkService = new MagicLinkService(hmppsAuthClient)
   const scanBarcodeService = new ScanBarcodeService(hmppsAuthClient)
   const createBarcodeService = new CreateBarcodeService()
-  const prisonRegisterService = new PrisonRegisterService()
+  const prisonRegisterService = new PrisonRegisterService(new PrisonRegisterStore())
   const appInsightsService = new AppInsightsService(appInsightsTelemetryClient)
 
   return createApp(

--- a/server/routes/barcode/FindRecipientView.ts
+++ b/server/routes/barcode/FindRecipientView.ts
@@ -1,5 +1,5 @@
 import type { FindRecipientForm } from 'forms'
-import { Prison } from '../../services/prison/PrisonRegisterService'
+import { Prison } from '../../services/prison/PrisonTypes'
 
 export default class FindRecipientView {
   constructor(

--- a/server/routes/barcode/FindRecipientView.ts
+++ b/server/routes/barcode/FindRecipientView.ts
@@ -1,5 +1,5 @@
 import type { FindRecipientForm } from 'forms'
-import { Prison } from '../../services/prison/PrisonTypes'
+import { Prison } from '../../@types/prisonTypes'
 
 export default class FindRecipientView {
   constructor(

--- a/server/services/prison/PrisonRegisterService.spec.ts
+++ b/server/services/prison/PrisonRegisterService.spec.ts
@@ -2,32 +2,42 @@
 import nock from 'nock'
 import PrisonRegisterService from './PrisonRegisterService'
 import config from '../../config'
+import PrisonRegisterStore from '../../data/cache/PrisonRegisterStore'
 
-describe('Magic Link Service', () => {
+const prisonRegisterStore = {
+  setActivePrisons: jest.fn(),
+  getActivePrisons: jest.fn(),
+}
+
+describe('Prison Register Service', () => {
   let prisonRegisterService: PrisonRegisterService
   let mockedPrisonRegisterApi: nock.Scope
 
   beforeEach(() => {
     mockedPrisonRegisterApi = nock(config.apis.prisonRegister.url)
-    prisonRegisterService = new PrisonRegisterService()
+    prisonRegisterService = new PrisonRegisterService(prisonRegisterStore as unknown as PrisonRegisterStore)
   })
 
   afterEach(() => {
     nock.cleanAll()
+    prisonRegisterStore.getActivePrisons.mockReset()
+    prisonRegisterStore.setActivePrisons.mockReset()
   })
 
   describe('getActivePrisons', () => {
-    it('should make the request to the prison register without an authorization header', done => {
+    it('should make the request to the prison register without an authorization header', async () => {
+      prisonRegisterStore.getActivePrisons.mockResolvedValue(null)
       nock(config.apis.prisonRegister.url, {
         badheaders: ['authorization'],
       })
         .get('/prisons')
         .reply(200, [])
 
-      prisonRegisterService.getActivePrisons().then(() => done())
+      await prisonRegisterService.getActivePrisons()
     })
 
-    it('should get all active prisons from the prison register', done => {
+    it('should get all active prisons from the prison register given they are not in the redis store', async () => {
+      prisonRegisterStore.getActivePrisons.mockResolvedValue(null)
       mockedPrisonRegisterApi.get('/prisons').reply(200, [
         { prisonId: 'ALI', prisonName: 'Albany (HMP)', active: false },
         { prisonId: 'AKI', prisonName: 'Acklington (HMP)', active: false },
@@ -36,14 +46,52 @@ describe('Magic Link Service', () => {
         { prisonId: 'ASI', prisonName: 'Ashfield (HMP)', active: true },
       ])
 
-      prisonRegisterService.getActivePrisons().then(activePrisons => {
-        expect(activePrisons).toStrictEqual([
-          { id: 'KTI', name: 'Kennet (HMP)' },
-          { id: 'ACI', name: 'Altcourse (HMP)' },
-          { id: 'ASI', name: 'Ashfield (HMP)' },
-        ])
-        done()
-      })
+      const expectedActivePrisons = [
+        { id: 'KTI', name: 'Kennet (HMP)' },
+        { id: 'ACI', name: 'Altcourse (HMP)' },
+        { id: 'ASI', name: 'Ashfield (HMP)' },
+      ]
+
+      const activePrisons = await prisonRegisterService.getActivePrisons()
+
+      expect(activePrisons).toStrictEqual(expectedActivePrisons)
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(expectedActivePrisons)
+    })
+
+    it('should get all active prisons from the prison register given reading from redis throws an error', async () => {
+      prisonRegisterStore.getActivePrisons.mockRejectedValue('some error reading from redis')
+      mockedPrisonRegisterApi.get('/prisons').reply(200, [
+        { prisonId: 'ALI', prisonName: 'Albany (HMP)', active: false },
+        { prisonId: 'AKI', prisonName: 'Acklington (HMP)', active: false },
+        { prisonId: 'KTI', prisonName: 'Kennet (HMP)', active: true },
+        { prisonId: 'ACI', prisonName: 'Altcourse (HMP)', active: true },
+        { prisonId: 'ASI', prisonName: 'Ashfield (HMP)', active: true },
+      ])
+
+      const expectedActivePrisons = [
+        { id: 'KTI', name: 'Kennet (HMP)' },
+        { id: 'ACI', name: 'Altcourse (HMP)' },
+        { id: 'ASI', name: 'Ashfield (HMP)' },
+      ]
+
+      const activePrisons = await prisonRegisterService.getActivePrisons()
+
+      expect(activePrisons).toStrictEqual(expectedActivePrisons)
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(expectedActivePrisons)
+    })
+
+    it('should get all active prisons from the prison register store given they are already in the redis store', async () => {
+      const expectedActivePrisons = [
+        { id: 'KTI', name: 'Kennet (HMP)' },
+        { id: 'ASI', name: 'Ashfield (HMP)' },
+        { id: 'ACI', name: 'Altcourse (HMP)' },
+      ]
+      prisonRegisterStore.getActivePrisons.mockResolvedValue(expectedActivePrisons)
+
+      const activePrisons = await prisonRegisterService.getActivePrisons()
+
+      expect(activePrisons).toStrictEqual(expectedActivePrisons)
+      expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
     })
   })
 })

--- a/server/services/prison/PrisonRegisterService.ts
+++ b/server/services/prison/PrisonRegisterService.ts
@@ -2,7 +2,7 @@ import config from '../../config'
 import PrisonRegisterStore from '../../data/cache/PrisonRegisterStore'
 import RestClient from '../../data/restClient'
 import { PrisonDto } from '../../@types/prisonRegisterApiClientTypes'
-import { Prison } from './PrisonTypes'
+import { Prison } from '../../@types/prisonTypes'
 
 export default class PrisonRegisterService {
   constructor(private readonly prisonRegisterStore: PrisonRegisterStore) {}

--- a/server/services/prison/PrisonRegisterService.ts
+++ b/server/services/prison/PrisonRegisterService.ts
@@ -1,29 +1,37 @@
-import RestClient from '../../data/restClient'
 import config from '../../config'
+import PrisonRegisterStore from '../../data/cache/PrisonRegisterStore'
+import RestClient from '../../data/restClient'
 import { PrisonDto } from '../../@types/prisonRegisterApiClientTypes'
-
-export interface Prison {
-  id: string
-  name: string
-}
+import { Prison } from './PrisonTypes'
 
 export default class PrisonRegisterService {
+  constructor(private readonly prisonRegisterStore: PrisonRegisterStore) {}
+
   private static restClient(): RestClient {
     return new RestClient('Prison Register API Client', config.apis.prisonRegister)
   }
 
   async getActivePrisons(): Promise<Array<Prison>> {
-    return PrisonRegisterService.restClient()
-      .get({ path: '/prisons' })
-      .then(data =>
-        (data as Array<PrisonDto>)
-          .filter(prison => prison.active === true)
-          .map(prisonDto => {
-            return {
-              id: prisonDto.prisonId,
-              name: prisonDto.prisonName,
-            }
-          })
-      )
+    try {
+      const activePrisons = await this.prisonRegisterStore.getActivePrisons()
+      return activePrisons || this.retrieveAndCacheActivePrisons()
+    } catch (error) {
+      return this.retrieveAndCacheActivePrisons()
+    }
+  }
+
+  private async retrieveAndCacheActivePrisons(): Promise<Array<Prison>> {
+    // Active Prisons were not returned from the redis store. Retrieve them from the service and put them in the redis store.
+    const prisonDtos = (await PrisonRegisterService.restClient().get({ path: '/prisons' })) as Array<PrisonDto>
+    const activePrisons = prisonDtos
+      .filter(prison => prison.active === true)
+      .map(prisonDto => {
+        return {
+          id: prisonDto.prisonId,
+          name: prisonDto.prisonName,
+        }
+      })
+    this.prisonRegisterStore.setActivePrisons(activePrisons)
+    return activePrisons
   }
 }

--- a/server/services/prison/PrisonTypes.ts
+++ b/server/services/prison/PrisonTypes.ts
@@ -1,0 +1,4 @@
+export interface Prison {
+  id: string
+  name: string
+}


### PR DESCRIPTION
This PR wires in the PrisonRegisterStore into the PrisonRegisterService, so that the active prisons are cached in the store (redis)