### PR TITLE
SLM-73: Added filtering for active prison values to enable/disable prisons in deployed environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The app requires:
 * hmpps-auth - for authentication
 * nomis-user-roles-api - for authentication
 * redis - session store and token caching
+* prison-register - for returning details of prisons
 
 ### Running the app for development
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,6 +10,7 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     SEND_LEGAL_MAIL_API_URL: "https://send-legal-mail-api-dev.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
+    SUPPORTED_PRISONS: "SKI"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,6 +10,7 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
     SEND_LEGAL_MAIL_API_URL: "https://send-legal-mail-api-preprod.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-preprod.hmpps.service.justice.gov.uk"
+    SUPPORTED_PRISONS: "SKI"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/server/config.ts
+++ b/server/config.ts
@@ -94,4 +94,5 @@ export default {
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   gtmContainerId: get('GOOGLE_TAG_MANAGER_CONTAINER_ID', null),
   magicLinkValidityDuration: Number(get('MAGIC_LINK_VALIDITY_DURATION_IN_MINUTES', 60)),
+  supportedPrisons: get('SUPPORTED_PRISONS', ''),
 }

--- a/server/routes/barcode/FindRecipientController.test.ts
+++ b/server/routes/barcode/FindRecipientController.test.ts
@@ -1,0 +1,79 @@
+import { Request, Response } from 'express'
+import type { FindRecipientForm } from 'forms'
+import { SessionData } from 'express-session'
+import FindRecipientController from './FindRecipientController'
+import PrisonRegisterService from '../../services/prison/PrisonRegisterService'
+
+const req = {
+  session: {} as SessionData,
+  flash: jest.fn(),
+}
+const response = {
+  render: jest.fn(),
+}
+
+const prisonRegisterService = {
+  getActivePrisons: jest.fn(),
+}
+
+describe('FindRecipientController', () => {
+  let findRecipientController: FindRecipientController
+
+  beforeEach(() => {
+    findRecipientController = new FindRecipientController(prisonRegisterService as unknown as PrisonRegisterService)
+  })
+
+  afterEach(() => {
+    prisonRegisterService.getActivePrisons.mockReset()
+    response.render.mockReset()
+    req.session = {} as SessionData
+  })
+
+  describe('getFindRecipientView', () => {
+    it('should create and return view', async () => {
+      prisonRegisterService.getActivePrisons.mockResolvedValue([
+        { id: 'KTI', name: 'Kennet (HMP)' },
+        { id: 'ASI', name: 'Ashfield (HMP)' },
+        { id: 'ACI', name: 'Altcourse (HMP)' },
+      ])
+      req.session.barcode = '123456789012'
+      req.session.barcodeImageUrl = 'http://url/image.png'
+
+      const expectedRenderArgs = {
+        barcode: '123456789012',
+        barcodeImageUrl: 'http://url/image.png',
+        errors: [] as Array<Record<string, string>>,
+        form: {} as FindRecipientForm,
+        prisonRegister: [
+          { value: '', text: '' },
+          { value: 'ACI', text: 'Altcourse (HMP)' },
+          { value: 'ASI', text: 'Ashfield (HMP)' },
+          { value: 'KTI', text: 'Kennet (HMP)' },
+        ] as Array<Record<string, string>>,
+      }
+      await findRecipientController.getFindRecipientView(req as unknown as Request, response as unknown as Response)
+
+      expect(response.render).toHaveBeenCalledWith('pages/barcode/find-recipient', expectedRenderArgs)
+      expect(req.flash).toHaveBeenCalledWith('errors')
+    })
+
+    it('should create and return view with error given prison register service fails', async () => {
+      prisonRegisterService.getActivePrisons.mockRejectedValue('An error retrieving prison register')
+      req.session.barcode = '123456789012'
+      req.session.barcodeImageUrl = 'http://url/image.png'
+
+      const expectedRenderArgs = {
+        barcode: '123456789012',
+        barcodeImageUrl: 'http://url/image.png',
+        errors: [] as Array<Record<string, string>>,
+        form: {} as FindRecipientForm,
+        prisonRegister: [{ value: '', text: '' }] as Array<Record<string, string>>,
+      }
+      await findRecipientController.getFindRecipientView(req as unknown as Request, response as unknown as Response)
+
+      expect(response.render).toHaveBeenCalledWith('pages/barcode/find-recipient', expectedRenderArgs)
+      expect(req.flash).toHaveBeenCalledWith('errors', [{ text: 'There was an error retrieving the list of prisons' }])
+      expect(req.flash).toHaveBeenCalledWith('errors')
+    })
+  })
+})

--- a/server/routes/barcode/FindRecipientController.ts
+++ b/server/routes/barcode/FindRecipientController.ts
@@ -1,20 +1,39 @@
 import { Request, Response } from 'express'
 import FindRecipientView from './FindRecipientView'
 import PrisonRegisterService from '../../services/prison/PrisonRegisterService'
+import config from '../../config'
+import { Prison } from '../../@types/prisonTypes'
 
 export default class FindRecipientController {
   constructor(private readonly prisonRegisterService: PrisonRegisterService) {}
 
   async getFindRecipientView(req: Request, res: Response): Promise<void> {
-    return this.prisonRegisterService.getActivePrisons().then(activePrisons => {
-      const view = new FindRecipientView(
-        req.session?.findRecipientForm || {},
-        req.flash('errors'),
-        req.session.barcode,
-        req.session.barcodeImageUrl,
-        activePrisons
-      )
-      return res.render('pages/barcode/find-recipient', { ...view.renderArgs })
-    })
+    let activePrisons: Array<Prison>
+    try {
+      activePrisons = await this.prisonRegisterService.getActivePrisons()
+    } catch (error) {
+      req.flash('errors', [{ text: 'There was an error retrieving the list of prisons' }])
+      activePrisons = []
+    }
+
+    const view = new FindRecipientView(
+      req.session?.findRecipientForm || {},
+      req.flash('errors'),
+      req.session.barcode,
+      req.session.barcodeImageUrl,
+      this.filterSupportedPrisons(activePrisons)
+    )
+    return res.render('pages/barcode/find-recipient', { ...view.renderArgs })
+  }
+
+  private filterSupportedPrisons(activePrisons: Array<Prison>): Array<Prison> {
+    if (!config.supportedPrisons || config.supportedPrisons === '') {
+      return activePrisons
+    }
+
+    const supportedPrisons: Array<string> = config.supportedPrisons
+      .split(',')
+      .map(prisonId => prisonId.trim().toUpperCase())
+    return activePrisons.filter(prison => supportedPrisons.includes(prison.id.toUpperCase()))
   }
 }

--- a/server/services/prison/PrisonRegisterService.spec.ts
+++ b/server/services/prison/PrisonRegisterService.spec.ts
@@ -93,5 +93,17 @@ describe('Prison Register Service', () => {
       expect(activePrisons).toStrictEqual(expectedActivePrisons)
       expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
     })
+
+    it('should fail to get active prisons given nothing in redis store and calling prison register API fails', async () => {
+      prisonRegisterStore.getActivePrisons.mockResolvedValue(null)
+      mockedPrisonRegisterApi.get('/prisons').reply(404, 'Error calling the Prison Register API')
+
+      try {
+        await prisonRegisterService.getActivePrisons()
+      } catch (error) {
+        expect(error).toBe('Error calling the Prison Register API')
+        expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
+      }
+    })
   })
 })

--- a/server/services/prison/PrisonRegisterService.ts
+++ b/server/services/prison/PrisonRegisterService.ts
@@ -21,17 +21,22 @@ export default class PrisonRegisterService {
   }
 
   private async retrieveAndCacheActivePrisons(): Promise<Array<Prison>> {
-    // Active Prisons were not returned from the redis store. Retrieve them from the service and put them in the redis store.
-    const prisonDtos = (await PrisonRegisterService.restClient().get({ path: '/prisons' })) as Array<PrisonDto>
-    const activePrisons = prisonDtos
-      .filter(prison => prison.active === true)
-      .map(prisonDto => {
-        return {
-          id: prisonDto.prisonId,
-          name: prisonDto.prisonName,
-        }
-      })
-    this.prisonRegisterStore.setActivePrisons(activePrisons)
-    return activePrisons
+    try {
+      // Active Prisons were not returned from the redis store. Retrieve them from the service and put them in the redis store.
+      const prisonDtos = (await PrisonRegisterService.restClient().get({ path: '/prisons' })) as Array<PrisonDto>
+      const activePrisons = prisonDtos
+        .filter(prison => prison.active === true)
+        .map(prisonDto => {
+          return {
+            id: prisonDto.prisonId,
+            name: prisonDto.prisonName,
+          }
+        })
+      this.prisonRegisterStore.setActivePrisons(activePrisons)
+      return activePrisons
+    } catch (error) {
+      // There was an error calling the Prison Register API - return the error so it will be handled as part of the promise chain
+      return error
+    }
   }
 }


### PR DESCRIPTION
This PR enables support for an environment variable to filter the list of prisons presented on screen. This allows us to roll out the service to Legal Senders who interact with a subset of all prisons.