### PR TITLE
SLM-74 scan results page changes

### DIFF
--- a/assets/sass/application-ie8.sass
+++ b/assets/sass/application-ie8.sass
@@ -7,4 +7,5 @@ $path: "/assets/images/"
 @import './components/card'
 @import './components/manual-barcode-form'
 @import './components/scan-barcode-form'
+@import './components/scan-barcode-result'
 @import './local'

--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -8,4 +8,5 @@ $path: "/assets/images/"
 @import './components/card'
 @import './components/manual-barcode-form'
 @import './components/scan-barcode-form'
+@import './components/scan-barcode-result'
 @import './local'

--- a/assets/sass/components/_scan-barcode-result.scss
+++ b/assets/sass/components/_scan-barcode-result.scss
@@ -1,0 +1,20 @@
+#scan-barcode-result-notification {
+
+  .govuk-notification-banner__header {
+    height: 25px;
+
+    h2.govuk-notification-banner__title {
+      @extend .govuk-visually-hidden
+    }
+  }
+
+  .success {
+    .govuk-notification-banner__content p {
+      // hook class to enable styling of success banner such as applying green tick
+    }
+  }
+
+  .notification {
+    // hook class to enable styling of notification banners
+  }
+}

--- a/integration_tests/integration/e2e/mailroomJourneyE2e.spec.ts
+++ b/integration_tests/integration/e2e/mailroomJourneyE2e.spec.ts
@@ -28,7 +28,7 @@ context('Mailroom Journey E2E', () => {
 
     // Click the Further Checks link and arrive on the results page with appropriate content
     resultPage.clickFurtherChecksNecessary()
-    resultPage.hasMainHeading('Carry out further checks')
+    resultPage.hasMainHeading('Item of concern: carry out further checks')
 
     // From the result page, scan another valid barcode
     resultPage.submitFormWithValidBarcode()
@@ -36,17 +36,17 @@ context('Mailroom Journey E2E', () => {
 
     // Scan a barcode that is not recognised
     resultPage.submitFormWithBarcodeThatDoesNotExist()
-    resultPage.hasMainHeading('Carry out further checks')
+    resultPage.hasMainHeading('Barcode not recognised: carry out further checks')
 
     // Go to the manual barcode entry page to try entering if from there
     let manualBarcodeEntryPage = resultPage.clickToGoToManualBarcodeEntryPage()
     resultPage = manualBarcodeEntryPage.submitFormWithBarcodeThatDoesNotExist()
-    resultPage.hasMainHeading('Carry out further checks')
+    resultPage.hasMainHeading('Barcode not recognised: carry out further checks')
 
     // Go back to the manual barcode entry page and click the link that says we have a problem entering a barcode
     manualBarcodeEntryPage = resultPage.clickToGoToManualBarcodeEntryPage()
     resultPage = manualBarcodeEntryPage.problemEnteringBarcode()
-    resultPage.hasMainHeading('Carry out further checks')
+    resultPage.hasMainHeading(`Barcode doesn't scan: carry out further checks`)
 
     // From the result page, scan another valid barcode
     resultPage.submitFormWithValidBarcode()

--- a/integration_tests/integration/scan/manuallyEnterBarcode.spec.ts
+++ b/integration_tests/integration/scan/manuallyEnterBarcode.spec.ts
@@ -59,7 +59,7 @@ context('Manual Barcode Entry Page', () => {
     const scanBarcodeResultPage: ScanBarcodeResultPage =
       manualBarcodeEntryPage.submitFormWithBarcodeThatHasBeenScannedPreviously()
 
-    scanBarcodeResultPage.hasMainHeading('Carry out further checks')
+    scanBarcodeResultPage.hasMainHeading('Barcode already scanned: carry out further checks')
   })
 
   it('should render barcode results page given form submitted with barcode that has been selected for a random check', () => {
@@ -84,7 +84,7 @@ context('Manual Barcode Entry Page', () => {
 
     const scanBarcodeResultPage: ScanBarcodeResultPage = manualBarcodeEntryPage.submitFormWithBarcodeThatHasExpired()
 
-    scanBarcodeResultPage.hasMainHeading('Carry out further checks')
+    scanBarcodeResultPage.hasMainHeading('Barcode expired: carry out further checks')
   })
 
   it('should render barcode results page given form submitted with barcode that cannot be found', () => {
@@ -96,7 +96,7 @@ context('Manual Barcode Entry Page', () => {
 
     const scanBarcodeResultPage: ScanBarcodeResultPage = manualBarcodeEntryPage.submitFormWithBarcodeThatDoesNotExist()
 
-    scanBarcodeResultPage.hasMainHeading('Carry out further checks')
+    scanBarcodeResultPage.hasMainHeading('Barcode not recognised: carry out further checks')
   })
 
   it('should render barcode results given user indicates they cannot enter the barcode', () => {

--- a/integration_tests/integration/scan/scanBarcode.spec.ts
+++ b/integration_tests/integration/scan/scanBarcode.spec.ts
@@ -66,7 +66,7 @@ context('Scan Barcode Page', () => {
     const scanBarcodeResultPage: ScanBarcodeResultPage =
       scanBarcodePage.submitFormWithBarcodeThatHasBeenScannedPreviously()
 
-    scanBarcodeResultPage.hasMainHeading('Carry out further checks')
+    scanBarcodeResultPage.hasMainHeading('Barcode already scanned: carry out further checks')
   })
 
   it('should render barcode results page given form submitted with barcode that has been selected for a random check', () => {
@@ -91,7 +91,7 @@ context('Scan Barcode Page', () => {
 
     const scanBarcodeResultPage: ScanBarcodeResultPage = scanBarcodePage.submitFormWithBarcodeThatHasExpired()
 
-    scanBarcodeResultPage.hasMainHeading('Carry out further checks')
+    scanBarcodeResultPage.hasMainHeading('Barcode expired: carry out further checks')
   })
 
   it('should render barcode results page given form submitted with barcode that cannot be found', () => {
@@ -103,7 +103,7 @@ context('Scan Barcode Page', () => {
 
     const scanBarcodeResultPage: ScanBarcodeResultPage = scanBarcodePage.submitFormWithBarcodeThatDoesNotExist()
 
-    scanBarcodeResultPage.hasMainHeading('Carry out further checks')
+    scanBarcodeResultPage.hasMainHeading('Barcode not recognised: carry out further checks')
   })
 
   it('should redisplay form with errors given form submitted with invalid barcode', () => {

--- a/integration_tests/integration/scan/scanBarcodeResult.spec.ts
+++ b/integration_tests/integration/scan/scanBarcodeResult.spec.ts
@@ -37,7 +37,7 @@ context('Scan Barcode Result Page', () => {
 
     resultPage.clickFurtherChecksNecessary()
 
-    Page.verifyOnPage(ScanBarcodeResultPage).hasMainHeading('Carry out further checks')
+    Page.verifyOnPage(ScanBarcodeResultPage).hasMainHeading('Item of concern: carry out further checks')
   })
 
   it('Unauthenticated user can not navigate to scan barcode result page', () => {

--- a/server/views/pages/scan/scan-barcode-result.njk
+++ b/server/views/pages/scan/scan-barcode-result.njk
@@ -18,27 +18,29 @@
       }) }}
     {% endif %}
 
-    {% if form.errorCode == null %}
-      {% include "partials/scan/scan-barcode-result-ok.njk" %}
-    {% endif %}
-    {% if form.errorCode.code == 'DUPLICATE' %}
-      {% include "partials/scan/scan-barcode-result-duplicate.njk" %}
-    {% endif %}
-    {% if form.errorCode.code == 'RANDOM_CHECK' %}
-      {% include "partials/scan/scan-barcode-result-random-check.njk" %}
-    {% endif %}
-    {% if form.errorCode.code == 'EXPIRED' %}
-      {% include "partials/scan/scan-barcode-result-expired.njk" %}
-    {% endif %}
-    {% if form.errorCode.code == 'NOT_FOUND' %}
-      {% include "partials/scan/scan-barcode-result-not-found.njk" %}
-    {% endif %}
-    {% if form.errorCode.code == 'CANNOT_ENTER_BARCODE' %}
-      {% include "partials/scan/scan-barcode-result-cannot-enter-barcode.njk" %}
-    {% endif %}
-    {% if form.errorCode.code == 'FURTHER_CHECKS_NEEDED' %}
-      {% include "partials/scan/scan-barcode-result-further-checks-needed.njk" %}
-    {% endif %}
+    <section id="scan-barcode-result-notification">
+      {% if form.errorCode == null %}
+        {% include "partials/scan/scan-barcode-result-ok.njk" %}
+      {% endif %}
+      {% if form.errorCode.code == 'DUPLICATE' %}
+        {% include "partials/scan/scan-barcode-result-duplicate.njk" %}
+      {% endif %}
+      {% if form.errorCode.code == 'RANDOM_CHECK' %}
+        {% include "partials/scan/scan-barcode-result-random-check.njk" %}
+      {% endif %}
+      {% if form.errorCode.code == 'EXPIRED' %}
+        {% include "partials/scan/scan-barcode-result-expired.njk" %}
+      {% endif %}
+      {% if form.errorCode.code == 'NOT_FOUND' %}
+        {% include "partials/scan/scan-barcode-result-not-found.njk" %}
+      {% endif %}
+      {% if form.errorCode.code == 'CANNOT_ENTER_BARCODE' %}
+        {% include "partials/scan/scan-barcode-result-cannot-enter-barcode.njk" %}
+      {% endif %}
+      {% if form.errorCode.code == 'FURTHER_CHECKS_NEEDED' %}
+        {% include "partials/scan/scan-barcode-result-further-checks-needed.njk" %}
+      {% endif %}
+    </section>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds" id="scan-barcode-form">

--- a/server/views/pages/scan/scan-barcode-result.test.ts
+++ b/server/views/pages/scan/scan-barcode-result.test.ts
@@ -46,9 +46,9 @@ describe('Scan Barcode Result View', () => {
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('h1').text()).toEqual('Carry out further checks')
+    expect($('h1').text()).toEqual('Barcode already scanned: carry out further checks')
+    expect($('.govuk-notification-banner__content p strong').text()).toContain('9:11 am on 8 December 2021 at LEI')
     expect($('li strong').text()).toContain('Aardvark Lawyers')
-    expect($('p strong').text()).toContain('9:11 am on 8 December 2021 at LEI')
   })
 
   it('should render view for Random Check scan', () => {
@@ -68,7 +68,7 @@ describe('Scan Barcode Result View', () => {
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
     expect($('h1').text()).toEqual('Item selected for a random check')
-    expect($('p strong').text()).toContain('Aardvark Lawyers')
+    expect($('.govuk-notification-banner__content p').text()).toContain('Aardvark Lawyers')
   })
 
   it('should render view for Expired scan', () => {
@@ -92,7 +92,7 @@ describe('Scan Barcode Result View', () => {
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('h1').text()).toEqual('Carry out further checks')
+    expect($('h1').text()).toEqual('Barcode expired: carry out further checks')
     expect($('li strong').text()).toContain('Aardvark Lawyers')
     expect($('p strong').text()).toContain(`42 days ago, on ${createdDate.format('D MMMM YYYY')}`)
     expect($('p').text()).toContain(`longer than 14 days to arrive`)
@@ -112,8 +112,7 @@ describe('Scan Barcode Result View', () => {
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('h1').text()).toEqual('Carry out further checks')
-    expect($('p').text()).toContain('The barcode was not recognised')
+    expect($('h1').text()).toEqual('Barcode not recognised: carry out further checks')
   })
 
   it('should render view for user indicating a problem entering barcode', () => {
@@ -130,7 +129,7 @@ describe('Scan Barcode Result View', () => {
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('h1').text()).toEqual('Carry out further checks')
+    expect($('h1').text()).toEqual(`Barcode doesn't scan: carry out further checks`)
     expect($('p').text()).toContain(`barcode can't be linked to an approved sender`)
   })
 
@@ -142,7 +141,7 @@ describe('Scan Barcode Result View', () => {
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('h1').text()).toEqual('Carry out further checks')
-    expect($('p strong').text()).toContain('Aardvark Lawyers')
+    expect($('h1').text()).toEqual('Item of concern: carry out further checks')
+    expect($('li strong').text()).toContain('Aardvark Lawyers')
   })
 })

--- a/server/views/partials/scan/scan-barcode-result-cannot-enter-barcode.njk
+++ b/server/views/partials/scan/scan-barcode-result-cannot-enter-barcode.njk
@@ -5,10 +5,14 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Barcode doesn't scan: carry out further checks</h1>
 
+    {% set html %}
+      <p>You need to investigate this item because the barcode can't be linked to an approved sender.</p>
+    {% endset %}
+
     {{ govukNotificationBanner({
-      titleText: null,
-      text: 'You need to investigate this item because the barcode can\'t be linked to an approved sender.',
-      disableAutoFocus: true
+      html: html,
+      disableAutoFocus: true,
+      classes: 'notification barcode-doesnt-scan'
     }) }}
 
     <h2 class="govuk-heading-l">How to investigate</h2>

--- a/server/views/partials/scan/scan-barcode-result-cannot-enter-barcode.njk
+++ b/server/views/partials/scan/scan-barcode-result-cannot-enter-barcode.njk
@@ -3,10 +3,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">Carry out further checks</h1>
+    <h1 class="govuk-heading-xl">Barcode doesn't scan: carry out further checks</h1>
 
     {{ govukNotificationBanner({
-      text: 'Follow your usual procedure for checking Rule 39 mail.',
+      titleText: null,
+      text: 'You need to investigate this item because the barcode can\'t be linked to an approved sender.',
       disableAutoFocus: true
     }) }}
 
@@ -30,11 +31,5 @@
       html: html
     }) }}
 
-    <h3 class="govuk-heading-m">Why you need to carry out checks</h3>
-    <p>
-      You need to investigate this item because the barcode can't be linked to an approved sender.
-    </p>
-
-    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
   </div>
 </div>

--- a/server/views/partials/scan/scan-barcode-result-duplicate.njk
+++ b/server/views/partials/scan/scan-barcode-result-duplicate.njk
@@ -14,8 +14,8 @@
 
     {{ govukNotificationBanner({
       html: html,
-      titleText: null,
-      disableAutoFocus: true
+      disableAutoFocus: true,
+      classes: 'notification barcode-duplicate'
     }) }}
 
     <h2 class="govuk-heading-l">How to investigate</h2>

--- a/server/views/partials/scan/scan-barcode-result-duplicate.njk
+++ b/server/views/partials/scan/scan-barcode-result-duplicate.njk
@@ -3,17 +3,26 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">Carry out further checks</h1>
+    <h1 class="govuk-heading-xl">Barcode already scanned: carry out further checks</h1>
+
+    {% set html %}
+      <p>
+        Someone scanned this barcode at <strong>{{ form.errorCode.scannedDate | formatDateTimeForResultsPage }} at {{ form.errorCode.scannedLocation }}</strong>.
+        It may be an illegal copy.
+      </p>
+    {% endset %}
 
     {{ govukNotificationBanner({
-      text: 'Follow your usual procedure for checking Rule 39 mail.',
+      html: html,
+      titleText: null,
       disableAutoFocus: true
     }) }}
 
     <h2 class="govuk-heading-l">How to investigate</h2>
     <p>Follow your usual procedures to make sure:</p>
     <ul>
-        <li>that the sender, <strong>{{ form.errorCode.createdBy }}</strong>, has a record of sending this item</li>
+        <li>the mail is addressed to <strong>prisoner name TBC, prison number TBC</strong></li>
+        <li>the sender, <strong>{{ form.errorCode.createdBy }}</strong>, has a record of sending this item</li>
         <li>the item hasn't been tampered with</li>
         <li>there are no drugs or other contraband concealed in the item</li>
     </ul>
@@ -31,12 +40,5 @@
       html: html
     }) }}
 
-    <h3 class="govuk-heading-m">Why you need to carry out checks</h3>
-    <p>
-      Someone scanned this barcode at <strong>{{ form.errorCode.scannedDate | formatDateTimeForResultsPage }} at {{ form.errorCode.scannedLocation }}</strong>.
-      It may be an illegal copy.
-    </p>
-
-    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
   </div>
 </div>

--- a/server/views/partials/scan/scan-barcode-result-expired.njk
+++ b/server/views/partials/scan/scan-barcode-result-expired.njk
@@ -3,12 +3,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">Carry out further checks</h1>
+      <h1 class="govuk-heading-xl">Barcode expired: carry out further checks</h1>
 
-    {{ govukNotificationBanner({
-      text: 'Follow your usual procedure for checking Rule 39 mail.',
-      disableAutoFocus: true
-    }) }}
+      {% set html %}
+        <p>
+          This barcode was created <strong>{{ form.errorCode.createdDate | calculateDaysSinceCreation }} days ago, on {{ form.errorCode.createdDate | formatDateForResultsPage }}</strong>.
+        </p>
+        <p>
+          Because this item of mail took longer than {{ form.errorCode.barcodeExpiryDays }} days to arrive you need to investigate further.
+        </p>
+      {% endset %}
+
+      {{ govukNotificationBanner({
+        html: html,
+        titleText: null,
+        disableAutoFocus: true
+      }) }}
 
     <h2 class="govuk-heading-l">How to investigate</h2>
     <p>Follow your usual procedures to make sure:</p>
@@ -31,14 +41,5 @@
       html: html
     }) }}
 
-    <h3 class="govuk-heading-m">Why you need to carry out checks</h3>
-    <p>
-      This barcode was created <strong>{{ form.errorCode.createdDate | calculateDaysSinceCreation }} days ago, on {{ form.errorCode.createdDate | formatDateForResultsPage }}</strong>.
-    </p>
-    <p>
-      Because this item of mail took longer than {{ form.errorCode.barcodeExpiryDays }} days to arrive you need to investigate further.
-    </p>
-
-    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
   </div>
 </div>

--- a/server/views/partials/scan/scan-barcode-result-expired.njk
+++ b/server/views/partials/scan/scan-barcode-result-expired.njk
@@ -16,8 +16,8 @@
 
       {{ govukNotificationBanner({
         html: html,
-        titleText: null,
-        disableAutoFocus: true
+        disableAutoFocus: true,
+        classes: 'notification barcode-expired'
       }) }}
 
     <h2 class="govuk-heading-l">How to investigate</h2>

--- a/server/views/partials/scan/scan-barcode-result-further-checks-needed.njk
+++ b/server/views/partials/scan/scan-barcode-result-further-checks-needed.njk
@@ -3,16 +3,18 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">Carry out further checks</h1>
+    <h1 class="govuk-heading-xl">Item of concern: carry out further checks</h1>
 
     {{ govukNotificationBanner({
-      text: 'Follow your usual procedure for checking Rule 39 mail.',
+      titleText: null,
+      text: 'You have concerns about this item of mail.',
       disableAutoFocus: true
     }) }}
 
     <h2 class="govuk-heading-l">How to investigate</h2>
     <p>Follow your usual procedures to make sure:</p>
     <ul>
+        <li>that the sender, <strong>{{ form.createdBy }}</strong>, has a record of sending this item</li>
         <li>the item hasn't been tampered with</li>
         <li>there are no drugs or other contraband concealed in the item</li>
     </ul>
@@ -30,11 +32,5 @@
       html: html
     }) }}
 
-    <h3 class="govuk-heading-m">Why you need to carry out checks</h3>
-    <p>
-      You have concerns about this item which was sent by <strong>{{ form.createdBy }}</strong>.
-    </p>
-
-    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
   </div>
 </div>

--- a/server/views/partials/scan/scan-barcode-result-further-checks-needed.njk
+++ b/server/views/partials/scan/scan-barcode-result-further-checks-needed.njk
@@ -5,10 +5,14 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Item of concern: carry out further checks</h1>
 
+    {% set html %}
+      <p>You have concerns about this item of mail.</p>
+    {% endset %}
+
     {{ govukNotificationBanner({
-      titleText: null,
-      text: 'You have concerns about this item of mail.',
-      disableAutoFocus: true
+      html: html,
+      disableAutoFocus: true,
+      classes: 'notification barcode-further-checks'
     }) }}
 
     <h2 class="govuk-heading-l">How to investigate</h2>

--- a/server/views/partials/scan/scan-barcode-result-not-found.njk
+++ b/server/views/partials/scan/scan-barcode-result-not-found.njk
@@ -5,10 +5,14 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Barcode not recognised: carry out further checks</h1>
 
+    {% set html %}
+      <p>The barcode number was not recognised. It may be a forgery.</p>
+    {% endset %}
+
     {{ govukNotificationBanner({
-      titleText: null,
-      text: 'The barcode number was not recognised. It may be a forgery.',
-      disableAutoFocus: true
+      html: html,
+      disableAutoFocus: true,
+      classes: 'notification barcode-not-found'
     }) }}
 
     <h2 class="govuk-heading-l">How to investigate</h2>

--- a/server/views/partials/scan/scan-barcode-result-not-found.njk
+++ b/server/views/partials/scan/scan-barcode-result-not-found.njk
@@ -3,10 +3,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">Carry out further checks</h1>
+    <h1 class="govuk-heading-xl">Barcode not recognised: carry out further checks</h1>
 
     {{ govukNotificationBanner({
-      text: 'Follow your usual procedure for checking Rule 39 mail.',
+      titleText: null,
+      text: 'The barcode number was not recognised. It may be a forgery.',
       disableAutoFocus: true
     }) }}
 
@@ -30,11 +31,5 @@
       html: html
     }) }}
 
-    <h3 class="govuk-heading-m">Why you need to carry out checks</h3>
-    <p>
-      The barcode was not recognised. It may be a forgery.
-    </p>
-
-    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
   </div>
 </div>

--- a/server/views/partials/scan/scan-barcode-result-ok.njk
+++ b/server/views/partials/scan/scan-barcode-result-ok.njk
@@ -5,19 +5,18 @@
     <h1 class="govuk-heading-xl">Ready for final delivery</h1>
 
     {% set html %}
-      <p class="govuk-notification-banner__heading">This item of mail was sent by an approved sender: {{ form.createdBy }}</p>
+      <p>This item of mail was sent by an approved sender: <strong>{{ form.createdBy }}</strong>.</p>
     {% endset %}
 
     {{ govukNotificationBanner({
       type: 'success',
+      titleText: null,
       html: html,
       disableAutoFocus: true
     }) }}
 
     <h2 class="govuk-heading-l">If you still have concerns about the item</h2>
-    <p>Even though this item was sent by an approved sender, you think it needs further investigation.</p>
-    <a href="/scan-barcode/further-checks-needed" class="govuk-link" id="further-checks">Further checks are needed</a>
-
-    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+    <p>Even though this item was sent by an approved sender, you think it needs to be checked.</p>
+    <a href="/scan-barcode/further-checks-needed" class="govuk-link" id="further-checks">I want to investigate further</a>
   </div>
 </div>

--- a/server/views/partials/scan/scan-barcode-result-ok.njk
+++ b/server/views/partials/scan/scan-barcode-result-ok.njk
@@ -10,9 +10,9 @@
 
     {{ govukNotificationBanner({
       type: 'success',
-      titleText: null,
       html: html,
-      disableAutoFocus: true
+      disableAutoFocus: true,
+      classes: 'success'
     }) }}
 
     <h2 class="govuk-heading-l">If you still have concerns about the item</h2>

--- a/server/views/partials/scan/scan-barcode-result-random-check.njk
+++ b/server/views/partials/scan/scan-barcode-result-random-check.njk
@@ -13,9 +13,9 @@
     {% endset %}
 
     {{ govukNotificationBanner({
-      titleText: null,
       html: html,
-      disableAutoFocus: true
+      disableAutoFocus: true,
+      classes: 'notification barcode-random-check'
     }) }}
 
     <h3 class="govuk-heading-m">How to deal with the item</h3>

--- a/server/views/partials/scan/scan-barcode-result-random-check.njk
+++ b/server/views/partials/scan/scan-barcode-result-random-check.njk
@@ -5,17 +5,18 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Item selected for a random check</h1>
 
+    {% set html %}
+      <p>
+        For additional security this item of mail has been selected for a random check.
+        It was sent by an approved sender, <strong>{{ form.errorCode.createdBy }}</strong>.
+      </p>
+    {% endset %}
+
     {{ govukNotificationBanner({
-      text: 'Carry out further checks appropriate to Rule 39 mail.',
+      titleText: null,
+      html: html,
       disableAutoFocus: true
     }) }}
-
-    <h2 class="govuk-heading-l">Why you need to carry out further checks</h2>
-    <p>
-      This item of mail was sent by an approved sender, <strong>{{ form.errorCode.createdBy }}</strong>,
-      but for additional security it has been selected for a random check.
-    </p>
-    <p>Carrying out random checks helps prevent Rule 39 mail being used for illegal purposes.</p>
 
     <h3 class="govuk-heading-m">How to deal with the item</h3>
     <p>Check the item for drugs or any other contraband using your usual procedures. For example, use any of the following:</p>
@@ -38,6 +39,5 @@
       html: html
     }) }}
 
-    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
   </div>
 </div>


### PR DESCRIPTION
This PR updates the Scan Results pages with the new content.
It does not replace the 'scan another barcode' form with the new 'Scan Another Barcode' button - that will be in the next PR. All this PR does is update the main content for each of the results pages - a few screenshots attached:

<img width="660" alt="Screenshot 2022-01-11 at 10 21 39" src="https://user-images.githubusercontent.com/94835226/148925959-2a8b6e61-974f-4c85-b862-1075d0e1a516.png">

<img width="657" alt="Screenshot 2022-01-11 at 10 22 17" src="https://user-images.githubusercontent.com/94835226/148925966-ede708fa-b0ec-470a-85a7-9213064ae239.png">

<img width="655" alt="Screenshot 2022-01-11 at 10 23 47" src="https://user-images.githubusercontent.com/94835226/148925969-06a707dc-42dd-49dc-9a3e-4c5d6debec3d.png">

<img width="654" alt="Screenshot 2022-01-11 at 10 24 28" src="https://user-images.githubusercontent.com/94835226/148925972-a5855adb-6c65-4fe9-91ba-4b00601a289b.png">

