### PR TITLE
SLM-74: Corrected typos identified as part of testing

### DIFF
--- a/integration_tests/integration/scan/scanBarcode.spec.ts
+++ b/integration_tests/integration/scan/scanBarcode.spec.ts
@@ -41,7 +41,7 @@ context('Scan Barcode Page', () => {
     cy.task('stubSignInWithRole_SLM_SCAN_BARCODE')
     cy.signIn()
     cy.visit('/scan-barcode')
-    Page.verifyOnPage(ScanBarcodePage).hasHeaderTitle('Check Rule 39 Mail')
+    Page.verifyOnPage(ScanBarcodePage).hasHeaderTitle('Check Rule 39 mail')
   })
 
   it('should render barcode results page given form submitted with barcode that verifies as OK', () => {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -17,7 +17,7 @@ export default function nunjucksSetup(app: express.Express): void {
   app.locals.asset_path = '/assets/'
   app.use((req, res, next) => {
     const externalUser = () => req.url.startsWith('/link') || req.url.startsWith('/barcode')
-    app.locals.applicationName = externalUser() ? 'Send Legal Mail To Prisons' : 'Check Rule 39 Mail'
+    app.locals.applicationName = externalUser() ? 'Send Legal Mail To Prisons' : 'Check Rule 39 mail'
     next()
   })
 

--- a/server/views/partials/scan/scan-barcode-result-random-check.njk
+++ b/server/views/partials/scan/scan-barcode-result-random-check.njk
@@ -23,7 +23,7 @@
     <ul>
         <li>trace detection equipment</li>
         <li>a dog unit</li>
-        <li>an xray machine</li>
+        <li>an X-ray machine</li>
     </ul>
 
     <p>If you have concerns about the item, report them to a security manager.</p>


### PR DESCRIPTION
Updated the text ('xray' → ‘X-ray’ and ‘Check Rule 39 Mail’ → ‘Check Rule 39 mail’) as requested:

<img width="990" alt="Screenshot 2022-01-13 at 08 47 32" src="https://user-images.githubusercontent.com/94835226/149297575-010084f8-91af-45e1-866b-5c12e92a050b.png">

