### PR TITLE
SLM-66: Refactored CreateBarcodeService as an enabler for PDF work

### DIFF
--- a/server/routes/barcode/GenerateBarcodeImageView.ts
+++ b/server/routes/barcode/GenerateBarcodeImageView.ts
@@ -1,17 +1,11 @@
 export default class GenerateBarcodeImageView {
-  constructor(
-    private readonly barcode: string,
-    private readonly barcodeImageUrl: string,
-    private readonly barcodeImageName: string
-  ) {}
+  constructor(private readonly barcodeImageUrl: string, private readonly barcodeImageName: string) {}
 
   get renderArgs(): {
-    barcode: string
     barcodeImageUrl: string
     barcodeImageName: string
   } {
     return {
-      barcode: this.barcode,
       barcodeImageUrl: this.barcodeImageUrl,
       barcodeImageName: this.barcodeImageName,
     }


### PR DESCRIPTION
Refactored `CreateBarcodeService` so that there is only one public method, meaning consumers of this service do not need to know which methods to call in which order. 