### PR TITLE
SLM-66: Added 'Select Envelope Size' page

### DIFF
--- a/assets/sass/application-ie8.sass
+++ b/assets/sass/application-ie8.sass
@@ -9,4 +9,5 @@ $path: "/assets/images/"
 @import './components/scan-barcode-form'
 @import './components/scan-barcode-result'
 @import './components/create-new-contact-form'
+@import './components/select-envelope-size-form'
 @import './local'

--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -10,4 +10,5 @@ $path: "/assets/images/"
 @import './components/scan-barcode-form'
 @import './components/scan-barcode-result'
 @import './components/create-new-contact-form'
+@import './components/select-envelope-size-form'
 @import './local'

--- a/assets/sass/components/_select-envelope-size-form.scss
+++ b/assets/sass/components/_select-envelope-size-form.scss
@@ -1,0 +1,65 @@
+#select-envelope-size-form {
+
+  .govuk-label {
+    display: block;
+  }
+
+  .govuk-label div {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    width: 100%;
+
+    .label {
+      font-weight: bold;
+      width: 33%;
+    }
+
+    .description {
+      width: 33%;
+    }
+
+    .specification {
+      margin-left: 1rem;
+      width: 66%;
+      height: 100%;
+      position: relative;
+    }
+    .specification::before {
+      position: absolute;
+      content: ' ';
+      border: 1px solid black;
+      top: 1.6rem;
+      left: 0;
+      width: 130px;
+    }
+    .specification::after {
+      position: absolute;
+      content: ' ';
+      border: 1px dotted gray;
+      height: 20px;
+      width: 70px;
+      left: 16px;
+      top: calc(1.6rem + 20px)
+    }
+  }
+
+  .govuk-label div.d4 {
+    height: calc(2rem + 60px);
+    .specification::before {
+      height: 60px;
+    }
+  }
+  .govuk-label div.c5 {
+    height: calc(2rem + 90px);
+    .specification::before {
+      height: 90px;
+    }
+  }
+  .govuk-label div.c4 {
+    height: calc(2rem + 180px);
+    .specification::before {
+      height: 180px;
+    }
+  }
+}

--- a/server/filters/renderEnvelopeSizeRadiosFilter.ts
+++ b/server/filters/renderEnvelopeSizeRadiosFilter.ts
@@ -1,0 +1,23 @@
+import { EnvelopeSizeSpec } from '../routes/barcode/PdfController'
+
+export type RadioButtonOption = {
+  value: string
+  html: string
+  checked: boolean
+}
+
+export default function renderEnvelopeSizeRadiosFilter(
+  envelopeSizes: Array<EnvelopeSizeSpec>
+): Array<RadioButtonOption> {
+  return envelopeSizes.map(envelopeSize => {
+    return {
+      value: envelopeSize.key,
+      html: `<div class='${envelopeSize.key}'>
+  <span class='label'>${envelopeSize.label}</span>
+  <span class='description'>(${envelopeSize.description})</span>
+  <span class='specification'>Width: ${envelopeSize.width}mm, height: ${envelopeSize.height}mm</span>
+</div>`,
+      checked: false,
+    }
+  })
+}

--- a/server/middleware/barcode/setupBarcode.ts
+++ b/server/middleware/barcode/setupBarcode.ts
@@ -5,6 +5,7 @@ import PrisonRegisterService from '../../services/prison/PrisonRegisterService'
 import ReviewRecipientsController from '../../routes/barcode/ReviewRecipientsController'
 import CreateContactController from '../../routes/barcode/CreateContactController'
 import GenerateBarcodeImageController from '../../routes/barcode/GenerateBarcodeImageController'
+import PdfController from '../../routes/barcode/PdfController'
 import ChooseBarcodeOptionController from '../../routes/barcode/ChooseBarcodeOptionController'
 
 export default function setUpCreateBarcode(
@@ -17,6 +18,7 @@ export default function setUpCreateBarcode(
   const reviewRecipientsController = new ReviewRecipientsController()
   const chooseBarcodeOptionController = new ChooseBarcodeOptionController()
   const generateImageController = new GenerateBarcodeImageController(createBarcodeService)
+  const pdfController = new PdfController()
 
   router.get('/find-recipient', (req, res) => findRecipientController.getFindRecipientByPrisonNumberView(req, res))
   router.post('/find-recipient/by-prison-number', (req, res) =>
@@ -34,6 +36,8 @@ export default function setUpCreateBarcode(
 
   router.get('/choose-barcode-option', (req, res) => chooseBarcodeOptionController.getChooseBarcodeOptionView(req, res))
   router.post('/choose-barcode-option', (req, res) => chooseBarcodeOptionController.submitChooseBarcodeOption(req, res))
+
+  router.get('/pdf/select-envelope-size', (req, res) => pdfController.getEnvelopeSizeView(req, res))
 
   router.get('/generate-barcode-image', (req, res) => generateImageController.getGenerateImageView(req, res))
 

--- a/server/routes/barcode/ChooseBarcodeOptionController.test.ts
+++ b/server/routes/barcode/ChooseBarcodeOptionController.test.ts
@@ -96,7 +96,7 @@ describe('ChooseBarcodeOptionController', () => {
       expect(res.redirect).toHaveBeenCalledWith('/barcode/choose-barcode-option')
     })
 
-    it('should redirect to barcode image page if form is valid', async () => {
+    it('should redirect to barcode image page if barcodeOption is image', async () => {
       req.body = { barcodeOption: 'image' }
       mockValidateBarcodeOption.mockReturnValue(true)
 
@@ -106,6 +106,18 @@ describe('ChooseBarcodeOptionController', () => {
       )
 
       expect(res.redirect).toHaveBeenCalledWith('/barcode/generate-barcode-image')
+    })
+
+    it('should redirect to barcode image page if barcodeOption is coversheet', async () => {
+      req.body = { barcodeOption: 'coversheet' }
+      mockValidateBarcodeOption.mockReturnValue(true)
+
+      await chooseBarcodeOptionController.submitChooseBarcodeOption(
+        req as unknown as Request,
+        res as unknown as Response
+      )
+
+      expect(res.redirect).toHaveBeenCalledWith('/barcode/pdf/select-envelope-size')
     })
   })
 })

--- a/server/routes/barcode/ChooseBarcodeOptionController.ts
+++ b/server/routes/barcode/ChooseBarcodeOptionController.ts
@@ -20,6 +20,8 @@ export default class ChooseBarcodeOptionController {
       return res.redirect('/barcode/choose-barcode-option')
     }
 
-    return res.redirect('/barcode/generate-barcode-image')
+    return req.session.chooseBarcodeOptionForm.barcodeOption === 'coversheet'
+      ? res.redirect('/barcode/pdf/select-envelope-size')
+      : res.redirect('/barcode/generate-barcode-image')
   }
 }

--- a/server/routes/barcode/PdfController.test.ts
+++ b/server/routes/barcode/PdfController.test.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from 'express'
+import { SessionData } from 'express-session'
+import PdfController from './PdfController'
+
+const req = {
+  session: {} as SessionData,
+  flash: jest.fn(),
+}
+
+const res = {
+  render: jest.fn(),
+  redirect: jest.fn(),
+}
+
+describe('PdfController', () => {
+  const pdfController = new PdfController()
+
+  afterEach(() => {
+    res.render.mockReset()
+    res.redirect.mockReset()
+    req.session = {} as SessionData
+    req.flash.mockReset()
+  })
+
+  describe('getEnvelopeSizeView', () => {
+    it('should redirect to find-recipient given no recipients in the session', async () => {
+      req.session.recipients = undefined
+
+      await pdfController.getEnvelopeSizeView(req as unknown as Request, res as unknown as Response)
+
+      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient')
+    })
+  })
+})

--- a/server/routes/barcode/PdfController.ts
+++ b/server/routes/barcode/PdfController.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from 'express'
+
+export type EnvelopeSizeSpec = {
+  key: string
+  label: string
+  description: string
+  width: number
+  height: number
+}
+const ENVELOPE_SIZES: Array<EnvelopeSizeSpec> = [
+  { key: 'd4', label: 'D4', description: 'A4 folder in thirds', width: 220, height: 110 },
+  { key: 'c5', label: 'C5', description: 'A4 folder in half or A5 not folded', width: 229, height: 162 },
+  { key: 'c4', label: 'C4', description: 'A4 not folded', width: 229, height: 324 },
+]
+
+export default class PdfController {
+  async getEnvelopeSizeView(req: Request, res: Response): Promise<void> {
+    if (!req.session.recipients) {
+      return res.redirect('/barcode/find-recipient')
+    }
+
+    return res.render('pages/barcode/pdf/select-envelope-size', { envelopeSizes: ENVELOPE_SIZES })
+  }
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -8,6 +8,7 @@ import findErrorFilter from '../filters/findErrorFilter'
 import calculateDaysSinceCreationFilter from '../filters/calculateDaysSinceCreationFilter'
 import formatDateTimeForResultsPageFilter from '../filters/formatDateTimeForResultsPageFilter'
 import formatDateForResultsPageFilter from '../filters/formatDateForResultsPageFilter'
+import renderEnvelopeSizeRadiosFilter from '../filters/renderEnvelopeSizeRadiosFilter'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -57,6 +58,7 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('formatDateForResultsPage', formatDateForResultsPageFilter)
   njkEnv.addFilter('calculateDaysSinceCreation', calculateDaysSinceCreationFilter)
   njkEnv.addFilter('recipientTableRows', recipientTableRowsFilter)
+  njkEnv.addFilter('renderEnvelopeSizeRadios', renderEnvelopeSizeRadiosFilter)
 
   return njkEnv
 }

--- a/server/views/pages/barcode/pdf/select-envelope-size.njk
+++ b/server/views/pages/barcode/pdf/select-envelope-size.njk
@@ -1,0 +1,52 @@
+{% extends "layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% set pageTitle = applicationName + " - Select envelope size" %}
+{% set pageId = 'select-envelope-size' %}
+
+{% block content %}
+
+  <section class="app-container govuk-body">
+    {% if errors.length > 0 %}
+      {{ govukErrorSummary({
+        titleText: 'There is a problem',
+        errorList: errors,
+        attributes: { 'data-qa-errors': true }
+      }) }}
+    {% endif %}
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-xl">Select envelope size</h1>
+
+        <form id="select-envelope-size-form">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+          {% call govukFieldset({ }) %}
+
+            {{ govukRadios({
+              name: 'envelopeSize',
+              fieldset: {
+                legend: {
+                  text: 'Select your envelope size',
+                  isPageHeading: false,
+                  classes: 'govuk-visually-hidden'
+                }
+              },
+              items: envelopeSizes | renderEnvelopeSizeRadios
+            }) }}
+
+            {{ govukButton({
+              text: 'Continue'
+            }) }}
+
+          {% endcall %}
+        </form>
+      </div>
+    </div>
+  </section>
+
+{% endblock %}


### PR DESCRIPTION
PR that adds the initial "Select Envelope Size" route and page (Temporary button to get to the page from "Review Recipients"; no POST endpoint for it to submit choice at this stage)


<img width="993" alt="Screenshot 2022-01-17 at 14 50 09" src="https://user-images.githubusercontent.com/94835226/149792028-de1c108a-fd01-4589-a8cb-36545c343d49.png">

