### PR TITLE
Add additional logging for when the callback from HMPPS Auth fails

### DIFF
--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -4,6 +4,7 @@ import passport from 'passport'
 import flash from 'connect-flash'
 import config from '../config'
 import auth from '../authentication/auth'
+import logger from '../../logger'
 
 const router = express.Router()
 
@@ -22,10 +23,18 @@ export default function setUpAuth(): Router {
   router.get('/sign-in', passport.authenticate('oauth2'))
 
   router.get('/sign-in/callback', (req, res, next) =>
-    passport.authenticate('oauth2', {
-      successReturnToOrRedirect: req.session.returnTo || '/',
-      failureRedirect: '/autherror',
-    })(req, res, next)
+    passport.authenticate(
+      'oauth2',
+      {
+        successReturnToOrRedirect: req.session.returnTo || '/',
+        failureRedirect: '/autherror',
+      },
+      (err, user, info) => {
+        if (err) {
+          logger.error(`authenticate return with err=${err}, user=${user}, info=${info}`)
+        }
+      }
+    )(req, res, next)
   )
 
   const authUrl = config.apis.hmppsAuth.externalUrl

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -4,7 +4,6 @@ import passport from 'passport'
 import flash from 'connect-flash'
 import config from '../config'
 import auth from '../authentication/auth'
-import logger from '../../logger'
 
 const router = express.Router()
 
@@ -23,18 +22,11 @@ export default function setUpAuth(): Router {
   router.get('/sign-in', passport.authenticate('oauth2'))
 
   router.get('/sign-in/callback', (req, res, next) =>
-    passport.authenticate(
-      'oauth2',
-      {
-        successReturnToOrRedirect: req.session.returnTo || '/',
-        failureRedirect: '/autherror',
-      },
-      (err, user, info) => {
-        if (err) {
-          logger.error(`authenticate return with err=${err}, user=${user}, info=${info}`)
-        }
-      }
-    )(req, res, next)
+    passport.authenticate('oauth2', {
+      successReturnToOrRedirect: req.session.returnTo || '/',
+      failureRedirect: '/autherror',
+      failureFlash: true,
+    })(req, res, next)
   )
 
   const authUrl = config.apis.hmppsAuth.externalUrl


### PR DESCRIPTION
See the `Custom Callback` section on https://www.passportjs.org/docs/authenticate/ for details on the callback.