### PR TITLE
SLM-94: Fix prison name autocomplete when either blank or non-matching prison name is selected

### DIFF
--- a/assets/js/page-enhancements.js
+++ b/assets/js/page-enhancements.js
@@ -30,6 +30,24 @@
         selectElement: element,
       })
     })
+    $('#create-new-contact-form').submit(event => {
+      // Before submitting the form set the prisonId select option to the value matching the autocomplete, or the null option if there is no match
+      // This is because the autocomplete currently only sets the select option when there is a valid match, which causes incorrect
+      // behaviour when the user performs a valid autocomplete, then changes it to blank or non-matching text. In this case the underlying
+      // select is not reset so we have to do it ourselves.
+      event.preventDefault()
+      const underlyingSelectField = $('#prisonId-select')
+      const autoCompleteField = $('#prisonId')
+      // In all cases start off by setting the underlying select option to the null/empty option
+      underlyingSelectField.children(`option[value='']`).prop('selected', true)
+      // Now find the option whose text matches the autocomplete field, and select it. If there is no match nothing will be selected
+      underlyingSelectField
+        .children('option')
+        .filter((idx, option) => option.text === autoCompleteField.val())
+        .prop('selected', true)
+      // Submit the form
+      event.target.submit()
+    })
   })
 })($, document)
 ;(enableCopyBarcodeButton = ($, document) => {

--- a/integration_tests/integration/barcode/createNewContact.spec.ts
+++ b/integration_tests/integration/barcode/createNewContact.spec.ts
@@ -1,6 +1,7 @@
 import FindRecipientByPrisonNumberPage from '../../pages/barcode/findRecipientByPrisonNumber'
 import Page from '../../pages/page'
 import ReviewRecipientsPage from '../../pages/barcode/reviewRecipients'
+import CreateNewContactPage from '../../pages/barcode/createNewContact'
 
 context('Create New Contact Page', () => {
   it('should redirect to find-recipient given user navigates to Create New Contact without going via find-recipients first', () => {
@@ -16,5 +17,29 @@ context('Create New Contact Page', () => {
     createNewContactPage.submitWithValidValues()
 
     Page.verifyOnPage(ReviewRecipientsPage)
+  })
+
+  it('should redisplay create-new-contact given form submitted with prison that was previously correctly selected but an invalid prison typed in', () => {
+    const createNewContactPage = FindRecipientByPrisonNumberPage.goToPage().submitWithValidPrisonNumber()
+
+    createNewContactPage
+      .enterAValidPrisonerName()
+      .typeAheadAValidPrison()
+      .typeAheadAnInvalidPrison()
+      .submitForm(CreateNewContactPage)
+
+    Page.verifyOnPage(CreateNewContactPage).hasPrisonIdErrorContaining('prison name')
+  })
+
+  it('should redisplay create-new-contact given form submitted with prison that was previously correctly selected but then blanked out', () => {
+    const createNewContactPage = FindRecipientByPrisonNumberPage.goToPage().submitWithValidPrisonNumber()
+
+    createNewContactPage
+      .enterAValidPrisonerName()
+      .typeAheadAValidPrison()
+      .clearPrisonField()
+      .submitForm(CreateNewContactPage)
+
+    Page.verifyOnPage(CreateNewContactPage).hasPrisonIdErrorContaining('prison name')
   })
 })

--- a/integration_tests/pages/barcode/createNewContact.ts
+++ b/integration_tests/pages/barcode/createNewContact.ts
@@ -14,15 +14,53 @@ export default class CreateNewContactPage extends Page {
   }
 
   submitWithValidValues = (): ReviewRecipientsPage => {
+    this.enterAValidPrisonerName()
+    this.typeAheadAValidPrison()
+    return this.submitForm(ReviewRecipientsPage)
+  }
+
+  enterAValidPrisonerName = (): CreateNewContactPage => {
+    this.prisonerNameField().clear()
     this.prisonerNameField().type('Gage Hewitt')
+    return this
+  }
+
+  typeAheadAValidPrison = (): CreateNewContactPage => {
+    this.clearPrisonField()
     this.prisonIdField().type('ashfield')
     this.pressEnterInPrisonIdField()
-    this.submitButton().click()
-    return Page.verifyOnPage(ReviewRecipientsPage)
+    return this
+  }
+
+  typeAheadAnInvalidPrison = (): CreateNewContactPage => {
+    this.clearPrisonField()
+    this.prisonIdField().type('not a valid prison')
+    this.pressEnterInPrisonIdField()
+    return this
+  }
+
+  clearPrisonField = (): CreateNewContactPage => {
+    this.prisonIdField().clear()
+    return this
   }
 
   pressEnterInPrisonIdField = () => {
     this.prisonIdField().type('\n')
+  }
+
+  submitForm<T>(T): T {
+    this.submitButton().click()
+    return Page.verifyOnPage(T)
+  }
+
+  hasPrisonerNameErrorContaining = (partialMessage: string): void => {
+    cy.get('.govuk-error-summary__list').should('contain', partialMessage)
+    cy.get('#prisonerName-error').should('contain', partialMessage)
+  }
+
+  hasPrisonIdErrorContaining = (partialMessage: string): void => {
+    cy.get('.govuk-error-summary__list').should('contain', partialMessage)
+    cy.get('#prisonId-error').should('contain', partialMessage)
   }
 
   prisonerNameField = (): PageElement => cy.get('#prisonerName')

--- a/server/views/pages/barcode/create-new-contact.njk
+++ b/server/views/pages/barcode/create-new-contact.njk
@@ -53,7 +53,8 @@
               label: {
                 text: 'Select name of prison'
               },
-              items: prisonRegister
+              items: prisonRegister,
+              errorMessage: errors | findError('prisonId')
             }) }}
 
             {{ govukButton({


### PR DESCRIPTION
This PR fixes SLM-94 which is the bug with autocomplete where blanking a previous valid valid, or changing a previous valid value to a non-matching value results in the previous value being submitted on the form.

As part of implementing the fix I have written a couple of cypress tests which assert the prison name field has the error highlight and message when in error, so I have also had to fix SLM-92 as part of this.