### PR TITLE
SLM-62 reafactor recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,28 +133,21 @@ Integration tests use the [cypress test runner](https://www.cypress.io/).
 
 #### Accessibility
 
-To test a page rendering for accessibility issues, write a test that uses [cypress-axe](https://github.com/component-driven/cypress-axe).
-For example:
-```
-  it('The page is accessible', () => {
-    cy.visit('/the-page-url')
-
-    cy.injectAxe()
-    cy.checkA11y(null, {
-      includedImpacts: ['critical', 'serious'],
-    })
-  })
-```
+Please use the Page superclass for all page models. By default, this will run an accessibility test every time the page 
+is loaded. For further details see `integration_tests/pages/page.ts`
 
 ### Dependency Checks
 
-The template project has implemented some scheduled checks to ensure that key dependencies are kept up to date.
-If these are not desired in the cloned project, remove references to `check_outdated` job from `.circleci/config.yml`
+Dependency checks are run in a nightly job on CircleCI. See job `check_outdated` in `.circleci/config.yml`
 
 ### Vulnerable dependencies
 To find any dependencies with vulnerabilities run command:
 
 `npm audit`
+
+#### Automated vulnerability checks
+
+Various security checks are run in a nightly job on CircleCI. See jobs `hmpps/npm_security_audit`, `hmpps/trivy_latest_scan` and `hmpps/veracode_pipeline_scan` in `.circleci/config.yml`.
 
 ### Update dependencies
 To update all dependencies to their latest stable versions run command:

--- a/integration_tests/mockApis/sendLegalMail.ts
+++ b/integration_tests/mockApis/sendLegalMail.ts
@@ -323,13 +323,13 @@ const stubCreateContact = (): SuperAgentRequest =>
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      body: `{
+      jsonBody: {
         id: 1,
-        prisonerName: {{jsonPath request.body '$.prisonerName'}},
-        prisonId: {{jsonPath request.body '$.prisonId'}},
-        prisonNumber: {{jsonPath request.body '$.prisonNumber'}},
-        prisonerDob: {{jsonPath request.body '$.prisonerDob'}},
-      }`,
+        prisonerName: `{{jsonPath request.body '$.prisonerName'}}`,
+        prisonId: `{{jsonPath request.body '$.prisonId'}}`,
+        prisonNumber: `{{jsonPath request.body '$.prisonNumber'}}`,
+        prisonerDob: `{{jsonPath request.body '$.prisonerDob'}}`,
+      },
     },
   })
 

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -32,7 +32,6 @@ declare module 'express-session' {
     findRecipientByPrisonerNameForm: FindRecipientByPrisonerNameForm
     createNewContactByPrisonerNameForm: CreateNewContactByPrisonerNameForm
     chooseContactForm: ChooseContactForm
-    contactSearchResults: Array<Contact>
     recipientForm: RecipientForm
   }
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,3 +1,4 @@
+import type { RecipientForm } from 'forms'
 import {
   BarcodeEntryForm,
   ChooseBarcodeOptionForm,
@@ -32,6 +33,7 @@ declare module 'express-session' {
     createNewContactByPrisonerNameForm: CreateNewContactByPrisonerNameForm
     chooseContactForm: ChooseContactForm
     contactSearchResults: Array<Contact>
+    recipientForm: RecipientForm
   }
 }
 

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -9,7 +9,6 @@ import {
   RequestLinkForm,
 } from '../forms'
 import { Recipient } from '../prisonTypes'
-import { Contact } from '../sendLegalMailApiClient'
 
 export default {}
 

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -1,5 +1,7 @@
 declare module 'forms' {
   import type { CheckBarcodeErrorCodes } from '../sendLegalMailApiClient'
+  import { PrisonAddress } from '../prisonTypes'
+  import { Contact } from '../sendLegalMailApiClient'
 
   export interface RequestLinkForm {
     email?: string
@@ -11,17 +13,14 @@ declare module 'forms' {
 
   export interface FindRecipientByPrisonerNameForm {
     prisonerName?: string
-    contacts?: Array<Contact>
   }
 
   export interface CreateNewContactByPrisonNumberForm {
-    prisonNumber: string
     prisonerName?: string
     prisonId?: string
   }
 
   export interface CreateNewContactByPrisonerNameForm {
-    prisonerName: string
     prisonId?: string
     prisonerDob?: Date
     'prisonerDob-day'?: string
@@ -51,6 +50,18 @@ declare module 'forms' {
   }
 
   export interface ChooseContactForm {
+    contactId?: string
+  }
+
+  export interface RecipientForm {
+    prisonNumber?: string
+    prisonerName?: string
+    prisonerDob?: Date
+    prisonId?: string
+    prisonAddress?: PrisonAddress
+    barcodeValue?: string
+    searchName?: string
+    contacts?: Array<Contact>
     contactId?: string
   }
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -31,6 +31,7 @@ import PrisonRegisterService from './services/prison/PrisonRegisterService'
 import GotenbergClient from './data/gotenbergClient'
 import setupPdfRenderer from './middleware/setupPdfRenderer'
 import ContactService from './services/contacts/ContactService'
+import RecipientFormService from './routes/barcode/recipients/RecipientFormService'
 
 export default function createApp(
   userService: UserService,
@@ -39,7 +40,8 @@ export default function createApp(
   createBarcodeService: CreateBarcodeService,
   prisonRegisterService: PrisonRegisterService,
   appInsightsClient: AppInsightsService,
-  contactService: ContactService
+  contactService: ContactService,
+  recipientFormService: RecipientFormService
 ): express.Application {
   const app = express()
 
@@ -64,7 +66,10 @@ export default function createApp(
   // authenticated with createBarcodeToken
   app.use('/barcode', barcodeAuthorisationMiddleware())
   app.use('/barcode', populateBarcodeUser())
-  app.use('/barcode', setUpCreateBarcode(createBarcodeService, prisonRegisterService, contactService))
+  app.use(
+    '/barcode',
+    setUpCreateBarcode(createBarcodeService, prisonRegisterService, contactService, recipientFormService)
+  )
 
   // authenticated by passport / HMPPS Auth
   app.use('/', setUpAuthentication())

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,7 @@ import AppInsightsService from './services/AppInsightsService'
 import PrisonRegisterService from './services/prison/PrisonRegisterService'
 import PrisonRegisterStore from './data/cache/PrisonRegisterStore'
 import ContactService from './services/contacts/ContactService'
+import RecipientFormService from './routes/barcode/recipients/RecipientFormService'
 
 const app = (appInsightsTelemetryClient?: TelemetryClient): express.Application => {
   const hmppsAuthClient = new HmppsAuthClient(new TokenStore())
@@ -21,6 +22,7 @@ const app = (appInsightsTelemetryClient?: TelemetryClient): express.Application 
   const prisonRegisterService = new PrisonRegisterService(new PrisonRegisterStore())
   const appInsightsService = new AppInsightsService(appInsightsTelemetryClient)
   const contactService = new ContactService()
+  const recipientFormService = new RecipientFormService(prisonRegisterService)
 
   return createApp(
     userService,
@@ -29,7 +31,8 @@ const app = (appInsightsTelemetryClient?: TelemetryClient): express.Application 
     createBarcodeService,
     prisonRegisterService,
     appInsightsService,
-    contactService
+    contactService,
+    recipientFormService
   )
 }
 

--- a/server/middleware/barcode/setupBarcode.ts
+++ b/server/middleware/barcode/setupBarcode.ts
@@ -9,21 +9,25 @@ import PdfController from '../../routes/barcode/pdf/PdfController'
 import ChooseBarcodeOptionController from '../../routes/barcode/options/ChooseBarcodeOptionController'
 import CreateContactByPrisonerNameController from '../../routes/barcode/contacts/CreateContactByPrisonerNameController'
 import ContactService from '../../services/contacts/ContactService'
+import RecipientFormService from '../../routes/barcode/recipients/RecipientFormService'
 
 export default function setUpCreateBarcode(
   createBarcodeService: CreateBarcodeService,
   prisonRegisterService: PrisonRegisterService,
-  contactService: ContactService
+  contactService: ContactService,
+  recipientFormService: RecipientFormService
 ): Router {
   const router = express.Router()
-  const findRecipientController = new FindRecipientController()
+  const findRecipientController = new FindRecipientController(recipientFormService)
   const createContactByPrisonNumberController = new CreateContactByPrisonNumberController(
     prisonRegisterService,
-    contactService
+    contactService,
+    recipientFormService
   )
   const createContactByPrisonerNameController = new CreateContactByPrisonerNameController(
     prisonRegisterService,
-    contactService
+    contactService,
+    recipientFormService
   )
   const reviewRecipientsController = new ReviewRecipientsController()
   const chooseBarcodeOptionController = new ChooseBarcodeOptionController()

--- a/server/routes/barcode/contacts/ChooseContactController.test.ts
+++ b/server/routes/barcode/contacts/ChooseContactController.test.ts
@@ -68,7 +68,7 @@ describe('ChooseContactController', () => {
     })
 
     it('should redirect to find recipient if prisoner name not in form', async () => {
-      req.session.findRecipientByPrisonerNameForm = {}
+      req.session.recipientForm = {}
 
       await chooseContactController.getChooseContact(req as unknown as Request, res as unknown as Response)
 
@@ -76,7 +76,7 @@ describe('ChooseContactController', () => {
     })
 
     it('should redirect to find recipient if there are no contacts in session', async () => {
-      req.session.findRecipientByPrisonerNameForm = { prisonerName: 'John Smith' }
+      req.session.recipientForm = { prisonerName: 'John Smith' }
 
       await chooseContactController.getChooseContact(req as unknown as Request, res as unknown as Response)
 
@@ -84,7 +84,7 @@ describe('ChooseContactController', () => {
     })
 
     it('should redirect to find recipient if the contact list is empty', async () => {
-      req.session.findRecipientByPrisonerNameForm = { prisonerName: 'John Smith', contacts: [] }
+      req.session.recipientForm = { prisonerName: 'John Smith', contacts: [] }
 
       await chooseContactController.getChooseContact(req as unknown as Request, res as unknown as Response)
 
@@ -92,7 +92,7 @@ describe('ChooseContactController', () => {
     })
 
     it('should display the view', async () => {
-      req.session.findRecipientByPrisonerNameForm = { prisonerName: 'John Smith', contacts: [aContact()] }
+      req.session.recipientForm = { prisonerName: 'John Smith', searchName: 'John Smith', contacts: [aContact()] }
       const expectedRenderArgs = {
         form: {},
         searchName: 'John Smith',
@@ -114,7 +114,7 @@ describe('ChooseContactController', () => {
     })
 
     it('should redirect to find recipient if there are no contacts to choose from', async () => {
-      req.session.findRecipientByPrisonerNameForm = { prisonerName: 'John Smith' }
+      req.session.recipientForm = { prisonerName: 'John Smith' }
 
       await chooseContactController.submitChooseContact(req as unknown as Request, res as unknown as Response)
 
@@ -122,7 +122,7 @@ describe('ChooseContactController', () => {
     })
 
     it('should redirect to find recipient if the contact list is empty', async () => {
-      req.session.findRecipientByPrisonerNameForm = { prisonerName: 'John Smith', contacts: [] }
+      req.session.recipientForm = { prisonerName: 'John Smith', contacts: [] }
 
       await chooseContactController.submitChooseContact(req as unknown as Request, res as unknown as Response)
 
@@ -130,7 +130,7 @@ describe('ChooseContactController', () => {
     })
 
     it('should show errors if contact not selected', async () => {
-      req.session.findRecipientByPrisonerNameForm = { prisonerName: 'John Smith', contacts: [aContact()] }
+      req.session.recipientForm = { prisonerName: 'John Smith', contacts: [aContact()] }
 
       await chooseContactController.submitChooseContact(req as unknown as Request, res as unknown as Response)
 
@@ -139,7 +139,7 @@ describe('ChooseContactController', () => {
     })
 
     it(`should show error if we can't find the prison address`, async () => {
-      req.session.findRecipientByPrisonerNameForm = { prisonerName: 'John Smith', contacts: [aContact()] }
+      req.session.recipientForm = { prisonerName: 'John Smith', contacts: [aContact()] }
       req.session.chooseContactForm = { contactId: '1' }
       req.session.contactSearchResults = [aContact()]
       prisonRegisterService.getPrisonAddress.mockRejectedValue('some error')
@@ -154,7 +154,7 @@ describe('ChooseContactController', () => {
     })
 
     it('should redirect to create new contact if selected', async () => {
-      req.session.findRecipientByPrisonerNameForm = { prisonerName: 'John Smith', contacts: [aContact()] }
+      req.session.recipientForm = { prisonerName: 'John Smith', contacts: [aContact()] }
       req.session.chooseContactForm = { contactId: '-1' }
 
       await chooseContactController.submitChooseContact(req as unknown as Request, res as unknown as Response)
@@ -163,7 +163,7 @@ describe('ChooseContactController', () => {
     })
 
     it('should add recipient if existing contact selected', async () => {
-      req.session.findRecipientByPrisonerNameForm = { prisonerName: 'John Smith', contacts: [aContact()] }
+      req.session.recipientForm = { prisonerName: 'John Smith', contacts: [aContact()] }
       req.session.chooseContactForm = { contactId: '1' }
       req.session.contactSearchResults = [aContact()]
       prisonRegisterService.getPrisonAddress.mockReturnValue(aPrisonAddress())

--- a/server/routes/barcode/contacts/ChooseContactController.test.ts
+++ b/server/routes/barcode/contacts/ChooseContactController.test.ts
@@ -1,12 +1,8 @@
 import { Request, Response } from 'express'
 import { SessionData } from 'express-session'
-import type { PrisonAddress } from 'prisonTypes'
 import type { Contact } from 'sendLegalMailApiClient'
-import PrisonRegisterService from '../../../services/prison/PrisonRegisterService'
-import ContactService from '../../../services/contacts/ContactService'
 import ChooseContactController from './ChooseContactController'
-
-jest.mock('../../../config')
+import RecipientFormService from '../recipients/RecipientFormService'
 
 const req = {
   session: {} as SessionData,
@@ -18,12 +14,14 @@ const res = {
   redirect: jest.fn(),
 }
 
-const prisonRegisterService = {
-  getPrisonAddress: jest.fn(),
-}
-
 const contactService = {
   searchContacts: jest.fn(),
+}
+
+const recipientFormService = {
+  requiresName: jest.fn(),
+  requiresContacts: jest.fn(),
+  addContact: jest.fn(),
 }
 
 const aContact = (): Contact => {
@@ -34,24 +32,17 @@ const aContact = (): Contact => {
   }
 }
 
-const aPrisonAddress = (): PrisonAddress => {
-  return {
-    premise: 'HMP Leeds',
-  }
-}
-
 describe('ChooseContactController', () => {
   let chooseContactController: ChooseContactController
 
   beforeEach(() => {
-    chooseContactController = new ChooseContactController(
-      contactService as unknown as ContactService,
-      prisonRegisterService as unknown as PrisonRegisterService
-    )
+    chooseContactController = new ChooseContactController(recipientFormService as unknown as RecipientFormService)
   })
 
   afterEach(() => {
-    prisonRegisterService.getPrisonAddress.mockReset()
+    recipientFormService.requiresName.mockReset()
+    recipientFormService.requiresContacts.mockReset()
+    recipientFormService.addContact.mockReset()
     contactService.searchContacts.mockReset()
     res.render.mockReset()
     res.redirect.mockReset()
@@ -61,34 +52,20 @@ describe('ChooseContactController', () => {
   })
 
   describe('getChooseContact', () => {
-    it('should redirect to find recipient if prisoner name form does not exist', async () => {
+    it('should redirect if requires name', async () => {
+      recipientFormService.requiresName.mockReturnValue('some-redirect')
+
       await chooseContactController.getChooseContact(req as unknown as Request, res as unknown as Response)
 
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient')
+      expect(res.redirect).toHaveBeenCalledWith('some-redirect')
     })
 
-    it('should redirect to find recipient if prisoner name not in form', async () => {
-      req.session.recipientForm = {}
+    it('should redirect if requires contacts', async () => {
+      recipientFormService.requiresContacts.mockReturnValue('some-redirect')
 
       await chooseContactController.getChooseContact(req as unknown as Request, res as unknown as Response)
 
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient')
-    })
-
-    it('should redirect to find recipient if there are no contacts in session', async () => {
-      req.session.recipientForm = { prisonerName: 'John Smith' }
-
-      await chooseContactController.getChooseContact(req as unknown as Request, res as unknown as Response)
-
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient/by-prisoner-name')
-    })
-
-    it('should redirect to find recipient if the contact list is empty', async () => {
-      req.session.recipientForm = { prisonerName: 'John Smith', contacts: [] }
-
-      await chooseContactController.getChooseContact(req as unknown as Request, res as unknown as Response)
-
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient/by-prisoner-name')
+      expect(res.redirect).toHaveBeenCalledWith('some-redirect')
     })
 
     it('should display the view', async () => {
@@ -107,26 +84,20 @@ describe('ChooseContactController', () => {
   })
 
   describe('submitChooseContact', () => {
-    it('should redirect to find recipient if prisoner name form does not exist', async () => {
+    it('should redirect if requires name', async () => {
+      recipientFormService.requiresName.mockReturnValue('some-redirect')
+
       await chooseContactController.submitChooseContact(req as unknown as Request, res as unknown as Response)
 
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient')
+      expect(res.redirect).toHaveBeenCalledWith('some-redirect')
     })
 
-    it('should redirect to find recipient if there are no contacts to choose from', async () => {
-      req.session.recipientForm = { prisonerName: 'John Smith' }
+    it('should redirect if requires contacts', async () => {
+      recipientFormService.requiresContacts.mockReturnValue('some-redirect')
 
       await chooseContactController.submitChooseContact(req as unknown as Request, res as unknown as Response)
 
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient/by-prisoner-name')
-    })
-
-    it('should redirect to find recipient if the contact list is empty', async () => {
-      req.session.recipientForm = { prisonerName: 'John Smith', contacts: [] }
-
-      await chooseContactController.submitChooseContact(req as unknown as Request, res as unknown as Response)
-
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient/by-prisoner-name')
+      expect(res.redirect).toHaveBeenCalledWith('some-redirect')
     })
 
     it('should show errors if contact not selected', async () => {
@@ -138,17 +109,17 @@ describe('ChooseContactController', () => {
       expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient/choose-contact')
     })
 
-    it(`should show error if we can't find the prison address`, async () => {
+    it(`should show error from adding the contact`, async () => {
       req.session.recipientForm = { prisonerName: 'John Smith', contacts: [aContact()] }
       req.session.chooseContactForm = { contactId: '1' }
       req.session.contactSearchResults = [aContact()]
-      prisonRegisterService.getPrisonAddress.mockRejectedValue('some error')
+      recipientFormService.addContact.mockRejectedValue('some-error')
 
       await chooseContactController.submitChooseContact(req as unknown as Request, res as unknown as Response)
 
-      expect(prisonRegisterService.getPrisonAddress).toHaveBeenCalledWith('LEI')
+      expect(recipientFormService.addContact).toHaveBeenCalledWith(req, aContact())
       expect(req.flash).toHaveBeenCalledWith('errors', [
-        { text: 'There was a problem getting the address for the selected prison. Please try again.' },
+        { text: 'There was a problem adding your contact. Please try again.' },
       ])
       expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient/choose-contact')
     })
@@ -166,17 +137,12 @@ describe('ChooseContactController', () => {
       req.session.recipientForm = { prisonerName: 'John Smith', contacts: [aContact()] }
       req.session.chooseContactForm = { contactId: '1' }
       req.session.contactSearchResults = [aContact()]
-      prisonRegisterService.getPrisonAddress.mockReturnValue(aPrisonAddress())
 
       await chooseContactController.submitChooseContact(req as unknown as Request, res as unknown as Response)
 
-      const recipient = req.session.recipients.find(rec => rec.prisonerName === 'John Smith')
-
-      expect(recipient).toBeTruthy()
-      expect(prisonRegisterService.getPrisonAddress).toHaveBeenCalledWith('LEI')
+      expect(recipientFormService.addContact).toHaveBeenCalledWith(expect.anything(), aContact())
       expect(res.redirect).toHaveBeenCalledWith('/barcode/review-recipients')
-      expect(req.session.findRecipientByPrisonerNameForm).toBeUndefined()
-      expect(req.session.createNewContactByPrisonerNameForm).toBeUndefined()
+      expect(req.session.chooseContactForm).toBeUndefined()
     })
   })
 })

--- a/server/routes/barcode/contacts/ChooseContactController.test.ts
+++ b/server/routes/barcode/contacts/ChooseContactController.test.ts
@@ -112,7 +112,6 @@ describe('ChooseContactController', () => {
     it(`should show error from adding the contact`, async () => {
       req.session.recipientForm = { prisonerName: 'John Smith', contacts: [aContact()] }
       req.session.chooseContactForm = { contactId: '1' }
-      req.session.contactSearchResults = [aContact()]
       recipientFormService.addContact.mockRejectedValue('some-error')
 
       await chooseContactController.submitChooseContact(req as unknown as Request, res as unknown as Response)
@@ -136,7 +135,6 @@ describe('ChooseContactController', () => {
     it('should add recipient if existing contact selected', async () => {
       req.session.recipientForm = { prisonerName: 'John Smith', contacts: [aContact()] }
       req.session.chooseContactForm = { contactId: '1' }
-      req.session.contactSearchResults = [aContact()]
 
       await chooseContactController.submitChooseContact(req as unknown as Request, res as unknown as Response)
 

--- a/server/routes/barcode/contacts/ChooseContactController.ts
+++ b/server/routes/barcode/contacts/ChooseContactController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import moment from 'moment'
-import type { PrisonAddress, Recipient } from 'prisonTypes'
+import type { Recipient } from 'prisonTypes'
 import type { Contact } from 'sendLegalMailApiClient'
 import PrisonRegisterService from '../../../services/prison/PrisonRegisterService'
 import ContactService from '../../../services/contacts/ContactService'
@@ -13,29 +13,26 @@ export default class ChooseContactController {
   ) {}
 
   async getChooseContact(req: Request, res: Response): Promise<void> {
-    if ((req.session.findRecipientByPrisonerNameForm?.prisonerName?.trim() ?? '') === '') {
+    if ((req.session.recipientForm?.prisonerName?.trim() ?? '') === '') {
       return res.redirect('/barcode/find-recipient')
     }
 
-    const contacts = req.session.findRecipientByPrisonerNameForm.contacts || []
-    if (contacts.length === 0) {
+    if ((req.session.recipientForm?.contacts ?? []).length === 0) {
       res.redirect('/barcode/find-recipient/by-prisoner-name')
     }
 
-    req.session.chooseContactForm = {}
-    const searchName = req.session.findRecipientByPrisonerNameForm.prisonerName
-    const view = new ChooseContactView(req.session.chooseContactForm, searchName, contacts, req.flash('errors'))
+    const { searchName, contacts } = req.session.recipientForm
+    const view = new ChooseContactView(req.session.chooseContactForm || {}, searchName, contacts, req.flash('errors'))
     return res.render('pages/barcode/choose-contact', { ...view.renderArgs })
   }
 
   async submitChooseContact(req: Request, res: Response): Promise<void> {
-    if (!req.session.findRecipientByPrisonerNameForm) {
+    if ((req.session.recipientForm?.prisonerName?.trim() ?? '') === '') {
       return res.redirect('/barcode/find-recipient')
     }
 
-    const contacts = req.session.findRecipientByPrisonerNameForm?.contacts || []
-    if (contacts.length === 0) {
-      return res.redirect('/barcode/find-recipient/by-prisoner-name')
+    if ((req.session.recipientForm?.contacts ?? []).length === 0) {
+      res.redirect('/barcode/find-recipient/by-prisoner-name')
     }
 
     const contactId = req.session.chooseContactForm?.contactId || ''
@@ -48,9 +45,15 @@ export default class ChooseContactController {
       const contact = this.findContact(req, contactId)
       try {
         const prisonAddress = await this.prisonRegisterService.getPrisonAddress(contact.prisonId)
-        this.addRecipient(req, contact, prisonAddress)
-        req.session.findRecipientByPrisonerNameForm = undefined
-        req.session.createNewContactByPrisonerNameForm = undefined
+        const newRecipient: Recipient = {
+          prisonNumber: contact.prisonNumber,
+          prisonerName: contact.prisonerName,
+          prisonerDob: moment(contact.dob, 'YYY-MM-DD').toDate(),
+          prisonAddress,
+        }
+        this.addRecipient(req, newRecipient)
+        req.session.chooseContactForm = undefined
+        req.session.recipientForm = undefined
         return res.redirect('/barcode/review-recipients')
       } catch (error) {
         req.flash('errors', [
@@ -61,6 +64,7 @@ export default class ChooseContactController {
     }
 
     // The user must have selected to create a new contact
+    req.session.chooseContactForm = undefined
     return res.redirect('/barcode/find-recipient/create-new-contact/by-prisoner-name')
   }
 
@@ -68,17 +72,11 @@ export default class ChooseContactController {
     return req.session.contactSearchResults.find((contact: Contact) => contact.id.toString() === contactId)
   }
 
-  private addRecipient(req: Request, contact: Contact, prisonAddress: PrisonAddress) {
+  private addRecipient(req: Request, newRecipient: Recipient) {
     if (!req.session.recipients) {
       req.session.recipients = []
     }
 
-    const recipient: Recipient = {
-      prisonerName: contact.prisonerName,
-      prisonerDob: moment(contact.dob, 'YYYY-MM-DD').toDate(),
-      prisonAddress,
-    }
-
-    req.session.recipients.push(recipient)
+    req.session.recipients.push(newRecipient)
   }
 }

--- a/server/routes/barcode/contacts/ChooseContactController.ts
+++ b/server/routes/barcode/contacts/ChooseContactController.ts
@@ -47,6 +47,6 @@ export default class ChooseContactController {
   }
 
   private findContact(req: Request, contactId: string): Contact | undefined {
-    return req.session.contactSearchResults.find((contact: Contact) => contact.id.toString() === contactId)
+    return req.session.recipientForm.contacts.find((contact: Contact) => contact.id.toString() === contactId)
   }
 }

--- a/server/routes/barcode/contacts/CreateContactByPrisonNumberController.test.ts
+++ b/server/routes/barcode/contacts/CreateContactByPrisonNumberController.test.ts
@@ -1,11 +1,11 @@
 import { Request, Response } from 'express'
 import { SessionData } from 'express-session'
-import type { PrisonAddress } from 'prisonTypes'
 import CreateContactByPrisonNumberController from './CreateContactByPrisonNumberController'
 import PrisonRegisterService from '../../../services/prison/PrisonRegisterService'
 import config from '../../../config'
 import newContactValidator from './newContactByPrisonNumberValidator'
 import ContactService from '../../../services/contacts/ContactService'
+import RecipientFormService from '../recipients/RecipientFormService'
 
 jest.mock('../../../config')
 jest.mock('./newContactByPrisonNumberValidator')
@@ -22,11 +22,15 @@ const res = {
 
 const prisonRegisterService = {
   getActivePrisons: jest.fn(),
-  getPrisonAddress: jest.fn(),
 }
 
 const contactService = {
   createContact: jest.fn(),
+}
+
+const recipientFormService = {
+  requiresPrisonNumber: jest.fn(),
+  addRecipient: jest.fn(),
 }
 
 describe('CreateContactByPrisonNumberController', () => {
@@ -35,13 +39,15 @@ describe('CreateContactByPrisonNumberController', () => {
   beforeEach(() => {
     createContactController = new CreateContactByPrisonNumberController(
       prisonRegisterService as unknown as PrisonRegisterService,
-      contactService as unknown as ContactService
+      contactService as unknown as ContactService,
+      recipientFormService as unknown as RecipientFormService
     )
   })
 
   afterEach(() => {
     prisonRegisterService.getActivePrisons.mockReset()
-    prisonRegisterService.getPrisonAddress.mockReset()
+    recipientFormService.addRecipient.mockReset()
+    recipientFormService.requiresPrisonNumber.mockReset()
     contactService.createContact.mockReset()
     res.render.mockReset()
     res.redirect.mockReset()
@@ -50,18 +56,12 @@ describe('CreateContactByPrisonNumberController', () => {
   })
 
   describe('getCreateNewRecipientView', () => {
-    it('should redirect to find recipient if prison number does not exist', async () => {
-      await createContactController.getCreateNewContact(req as unknown as Request, res as unknown as Response)
-
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient')
-    })
-
-    it('should redirect to find recipient if prison number not in form', async () => {
-      req.session.recipientForm = {}
+    it('should redirect if requires prison number', async () => {
+      recipientFormService.requiresPrisonNumber.mockReturnValue('some-redirect')
 
       await createContactController.getCreateNewContact(req as unknown as Request, res as unknown as Response)
 
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient')
+      expect(res.redirect).toHaveBeenCalledWith('some-redirect')
     })
 
     it('should create and return view given no active prison filtering', async () => {
@@ -151,7 +151,7 @@ describe('CreateContactByPrisonNumberController', () => {
       mockNewContactValidator = newContactValidator as jest.MockedFunction<typeof newContactValidator>
     })
 
-    it('should redirect to review-recipients given new contact is validated and prison address is resolved', async () => {
+    it('should redirect to review-recipients given new contact is valid', async () => {
       req.body = {
         prisonerName: 'Fred Bloggs',
         prisonId: 'SKI',
@@ -159,66 +159,46 @@ describe('CreateContactByPrisonNumberController', () => {
       req.session.recipientForm = { prisonNumber: 'A1234BC' }
       req.session.slmToken = 'some-token'
       mockNewContactValidator.mockReturnValue([])
-      const prisonAddress: PrisonAddress = {
-        agencyCode: 'CKI',
-        agyDescription: 'Cookham Wood (YOI)',
-        flat: null,
-        premise: 'HMP COOKHAM WOOD',
-        street: null,
-        locality: null,
-        countyCode: 'KENT',
-        area: 'Rochester Kent',
-        postalCode: 'ME1 3LU',
-      }
-      prisonRegisterService.getPrisonAddress.mockResolvedValue(prisonAddress)
-      const expectedRecipients = [{ prisonAddress, prisonNumber: 'A1234BC', prisonerName: 'Fred Bloggs' }]
 
       await createContactController.submitCreateNewContact(req as unknown as Request, res as unknown as Response)
 
       expect(res.redirect).toHaveBeenCalledWith('/barcode/review-recipients')
-      expect(req.session.recipients).toEqual(expectedRecipients)
-      expect(req.session.findRecipientByPrisonNumberForm).toBeUndefined()
+      expect(recipientFormService.addRecipient).toHaveBeenCalledWith(expect.anything())
       expect(req.session.createNewContactByPrisonNumberForm).toBeUndefined()
+      expect(req.session.recipientForm).toEqual({
+        prisonNumber: 'A1234BC',
+        prisonerName: 'Fred Bloggs',
+        prisonId: 'SKI',
+      })
       expect(contactService.createContact).toHaveBeenCalledWith('some-token', 'Fred Bloggs', 'SKI', 'A1234BC')
     })
 
-    it('should redirect to create-new-contact given new contact is validated but prison address is not resolved', async () => {
+    it('should redirect to create-new-contact if there is an error adding the recipient', async () => {
       req.body = {
         prisonerName: 'Fred Bloggs',
         prisonId: 'SKI',
       }
       req.session.recipientForm = { prisonNumber: 'A1234BC' }
       mockNewContactValidator.mockReturnValue([])
-      prisonRegisterService.getPrisonAddress.mockRejectedValue(new Error(`PrisonAddress for prison SKI not found`))
+      recipientFormService.addRecipient.mockRejectedValue('some-error')
 
       await createContactController.submitCreateNewContact(req as unknown as Request, res as unknown as Response)
 
       expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient/create-new-contact/by-prison-number')
       expect(req.flash).toHaveBeenCalledWith('errors', [
-        { href: 'prisonId', text: 'There was a problem getting the address for the selected prison' },
+        { href: 'prisonId', text: 'There was a problem adding your new recipient. Please try again.' },
       ])
     })
 
-    it('should redirect to create-new-contact given new contact is not validated', async () => {
-      req.body = { prisonerName: '', prisonId: 'SKI' }
-      req.session.recipientForm = { prisonNumber: 'A1234BC' }
-      mockNewContactValidator.mockReturnValue([{ href: '#prisonId', text: 'Select a prison name' }])
+    it('should redirect if requires prison number', async () => {
+      recipientFormService.requiresPrisonNumber.mockReturnValue('some-redirect')
 
-      await createContactController.submitCreateNewContact(req as unknown as Request, res as unknown as Response)
+      await createContactController.getCreateNewContact(req as unknown as Request, res as unknown as Response)
 
-      expect(req.flash).toHaveBeenCalledWith('errors', [{ href: '#prisonId', text: 'Select a prison name' }])
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient/create-new-contact/by-prison-number')
+      expect(res.redirect).toHaveBeenCalledWith('some-redirect')
     })
 
-    it('should redirect to find-recipient given no recipientForm in the session', async () => {
-      req.session.recipientForm = undefined
-
-      await createContactController.submitCreateNewContact(req as unknown as Request, res as unknown as Response)
-
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient')
-    })
-
-    it("`should ignore if we couldn't create the contact for any reason", async () => {
+    it('should redirect to review-recipients given new contact is valid', async () => {
       req.body = {
         prisonerName: 'Fred Bloggs',
         prisonId: 'SKI',
@@ -226,27 +206,18 @@ describe('CreateContactByPrisonNumberController', () => {
       req.session.recipientForm = { prisonNumber: 'A1234BC' }
       req.session.slmToken = 'some-token'
       mockNewContactValidator.mockReturnValue([])
-      const prisonAddress: PrisonAddress = {
-        agencyCode: 'CKI',
-        agyDescription: 'Cookham Wood (YOI)',
-        flat: null,
-        premise: 'HMP COOKHAM WOOD',
-        street: null,
-        locality: null,
-        countyCode: 'KENT',
-        area: 'Rochester Kent',
-        postalCode: 'ME1 3LU',
-      }
-      prisonRegisterService.getPrisonAddress.mockResolvedValue(prisonAddress)
-      contactService.createContact.mockRejectedValue(new Error('Some error creating the contact'))
-      const expectedRecipients = [{ prisonAddress, prisonNumber: 'A1234BC', prisonerName: 'Fred Bloggs' }]
+      contactService.createContact.mockRejectedValue('some-error')
 
       await createContactController.submitCreateNewContact(req as unknown as Request, res as unknown as Response)
 
       expect(res.redirect).toHaveBeenCalledWith('/barcode/review-recipients')
-      expect(req.session.recipients).toEqual(expectedRecipients)
-      expect(req.session.findRecipientByPrisonNumberForm).toBeUndefined()
+      expect(recipientFormService.addRecipient).toHaveBeenCalledWith(expect.anything())
       expect(req.session.createNewContactByPrisonNumberForm).toBeUndefined()
+      expect(req.session.recipientForm).toEqual({
+        prisonNumber: 'A1234BC',
+        prisonerName: 'Fred Bloggs',
+        prisonId: 'SKI',
+      })
       expect(contactService.createContact).toHaveBeenCalledWith('some-token', 'Fred Bloggs', 'SKI', 'A1234BC')
     })
   })

--- a/server/routes/barcode/contacts/CreateContactByPrisonNumberController.ts
+++ b/server/routes/barcode/contacts/CreateContactByPrisonNumberController.ts
@@ -1,22 +1,24 @@
 import { Request, Response } from 'express'
-import type { Prison, Recipient } from 'prisonTypes'
-import type { RecipientForm } from 'forms'
+import type { Prison } from 'prisonTypes'
 import validateNewContact from './newContactByPrisonNumberValidator'
 import PrisonRegisterService from '../../../services/prison/PrisonRegisterService'
 import CreateContactByPrisonNumberView from './CreateContactByPrisonNumberView'
 import filterSupportedPrisons from './filterSupportedPrisons'
 import ContactService from '../../../services/contacts/ContactService'
 import logger from '../../../../logger'
+import RecipientFormService from '../recipients/RecipientFormService'
 
 export default class CreateContactByPrisonNumberController {
   constructor(
     private readonly prisonRegisterService: PrisonRegisterService,
-    private readonly contactService: ContactService
+    private readonly contactService: ContactService,
+    private readonly recipientFormService: RecipientFormService
   ) {}
 
   async getCreateNewContact(req: Request, res: Response): Promise<void> {
-    if ((req.session.recipientForm?.prisonNumber?.trim() ?? '') === '') {
-      return res.redirect('/barcode/find-recipient')
+    const redirect = this.recipientFormService.requiresPrisonNumber(req)
+    if (redirect) {
+      return res.redirect(redirect)
     }
 
     let activePrisons: Array<Prison>
@@ -36,8 +38,9 @@ export default class CreateContactByPrisonNumberController {
   }
 
   async submitCreateNewContact(req: Request, res: Response): Promise<void> {
-    if ((req.session.recipientForm?.prisonNumber?.trim() ?? '') === '') {
-      return res.redirect('/barcode/find-recipient')
+    const redirect = this.recipientFormService.requiresPrisonNumber(req)
+    if (redirect) {
+      return res.redirect(redirect)
     }
 
     req.session.createNewContactByPrisonNumberForm = { ...req.body }
@@ -47,10 +50,11 @@ export default class CreateContactByPrisonNumberController {
       return res.redirect('/barcode/find-recipient/create-new-contact/by-prison-number')
     }
 
-    req.session.recipientForm.prisonerName = req.session.createNewContactByPrisonNumberForm.prisonerName
-    req.session.recipientForm.prisonId = req.session.createNewContactByPrisonNumberForm.prisonId
+    const { recipientForm, createNewContactByPrisonNumberForm } = req.session
+    recipientForm.prisonerName = createNewContactByPrisonNumberForm.prisonerName
+    recipientForm.prisonId = createNewContactByPrisonNumberForm.prisonId
     try {
-      const { prisonNumber, prisonerName, prisonId } = req.session.recipientForm
+      const { prisonNumber, prisonId, prisonerName } = recipientForm
       await this.contactService.createContact(req.session.slmToken, prisonerName, prisonId, prisonNumber)
     } catch (error) {
       logger.error(
@@ -62,34 +66,15 @@ export default class CreateContactByPrisonNumberController {
     }
 
     try {
-      req.session.recipientForm.prisonAddress = await this.prisonRegisterService.getPrisonAddress(
-        req.session.recipientForm.prisonId
-      )
-      this.addRecipient(req, req.session.recipientForm)
+      await this.recipientFormService.addRecipient(req)
       req.session.createNewContactByPrisonNumberForm = undefined
-      req.session.recipientForm = undefined
       return res.redirect('/barcode/review-recipients')
     } catch (error) {
-      // An error getting the prison address
+      logger.error(`Failed to add recipient ${JSON.stringify(req.session.recipientForm)} due to error:`, error)
       req.flash('errors', [
-        { href: 'prisonId', text: 'There was a problem getting the address for the selected prison' },
+        { href: 'prisonId', text: 'There was a problem adding your new recipient. Please try again.' },
       ])
       return res.redirect('/barcode/find-recipient/create-new-contact/by-prison-number')
     }
-  }
-
-  private addRecipient(req: Request, recipientForm: RecipientForm) {
-    if (!req.session.recipients) {
-      req.session.recipients = []
-    }
-
-    const newRecipient: Recipient = {
-      prisonerName: recipientForm.prisonerName || '',
-      prisonNumber: recipientForm.prisonNumber,
-      prisonerDob: recipientForm.prisonerDob,
-      prisonAddress: recipientForm.prisonAddress,
-    }
-
-    req.session.recipients.push(newRecipient)
   }
 }

--- a/server/routes/barcode/contacts/CreateContactByPrisonerNameController.test.ts
+++ b/server/routes/barcode/contacts/CreateContactByPrisonerNameController.test.ts
@@ -1,12 +1,12 @@
 import { Request, Response } from 'express'
 import { SessionData } from 'express-session'
 import moment from 'moment'
-import type { PrisonAddress } from 'prisonTypes'
 import PrisonRegisterService from '../../../services/prison/PrisonRegisterService'
 import config from '../../../config'
 import newContactValidator from './newContactByPrisonerNameValidator'
 import CreateContactByPrisonerNameController from './CreateContactByPrisonerNameController'
 import ContactService from '../../../services/contacts/ContactService'
+import RecipientFormService from '../recipients/RecipientFormService'
 
 jest.mock('../../../config')
 jest.mock('./newContactByPrisonerNameValidator')
@@ -23,11 +23,15 @@ const res = {
 
 const prisonRegisterService = {
   getActivePrisons: jest.fn(),
-  getPrisonAddress: jest.fn(),
 }
 
 const contactService = {
   createContact: jest.fn(),
+}
+
+const recipientFormService = {
+  requiresName: jest.fn(),
+  addRecipient: jest.fn(),
 }
 
 describe('CreateContactByPrisonerNameController', () => {
@@ -36,13 +40,15 @@ describe('CreateContactByPrisonerNameController', () => {
   beforeEach(() => {
     createContactController = new CreateContactByPrisonerNameController(
       prisonRegisterService as unknown as PrisonRegisterService,
-      contactService as unknown as ContactService
+      contactService as unknown as ContactService,
+      recipientFormService as unknown as RecipientFormService
     )
   })
 
   afterEach(() => {
     prisonRegisterService.getActivePrisons.mockReset()
-    prisonRegisterService.getPrisonAddress.mockReset()
+    recipientFormService.requiresName.mockReset()
+    recipientFormService.addRecipient.mockReset()
     contactService.createContact.mockReset()
     res.render.mockReset()
     res.redirect.mockReset()
@@ -52,18 +58,12 @@ describe('CreateContactByPrisonerNameController', () => {
   })
 
   describe('getCreateNewRecipientView', () => {
-    it('should redirect to find recipient if prisoner name form does not exist', async () => {
-      await createContactController.getCreateNewContact(req as unknown as Request, res as unknown as Response)
-
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient')
-    })
-
-    it('should redirect to find recipient if prisoner name not in form', async () => {
-      req.session.recipientForm = {}
+    it('should redirect if requires name', async () => {
+      recipientFormService.requiresName.mockReturnValue('some-redirect')
 
       await createContactController.getCreateNewContact(req as unknown as Request, res as unknown as Response)
 
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient')
+      expect(res.redirect).toHaveBeenCalledWith('some-redirect')
     })
 
     it('should create and return view given no active prison filtering', async () => {
@@ -153,7 +153,7 @@ describe('CreateContactByPrisonerNameController', () => {
       mockNewContactValidator = newContactValidator as jest.MockedFunction<typeof newContactValidator>
     })
 
-    it('should redirect to review-recipients given new contact is validated and prison address is resolved', async () => {
+    it('should redirect to review-recipients given new contact is valid', async () => {
       req.body = {
         prisonerDob: undefined,
         'prisonerDob-day': '1',
@@ -164,26 +164,17 @@ describe('CreateContactByPrisonerNameController', () => {
       req.session.recipientForm = { prisonerName: 'Fred Bloggs' }
       req.session.slmToken = 'some-token'
       mockNewContactValidator.mockReturnValue([])
-      const prisonAddress: PrisonAddress = {
-        agencyCode: 'CKI',
-        agyDescription: 'Cookham Wood (YOI)',
-        flat: null,
-        premise: 'HMP COOKHAM WOOD',
-        street: null,
-        locality: null,
-        countyCode: 'KENT',
-        area: 'Rochester Kent',
-        postalCode: 'ME1 3LU',
-      }
-      prisonRegisterService.getPrisonAddress.mockResolvedValue(prisonAddress)
-      const expectedRecipients = [{ prisonAddress, prisonerDob: new Date(1990, 0, 1), prisonerName: 'Fred Bloggs' }]
 
       await createContactController.submitCreateNewContact(req as unknown as Request, res as unknown as Response)
 
       expect(res.redirect).toHaveBeenCalledWith('/barcode/review-recipients')
-      expect(req.session.recipients).toEqual(expectedRecipients)
-      expect(req.session.recipientForm).toBeUndefined()
+      expect(recipientFormService.addRecipient).toHaveBeenCalledWith(expect.anything())
       expect(req.session.createNewContactByPrisonerNameForm).toBeUndefined()
+      expect(req.session.recipientForm).toEqual({
+        prisonerName: 'Fred Bloggs',
+        prisonId: 'SKI',
+        prisonerDob: moment('1990-01-01', 'YYYY-MM-DD').toDate(),
+      })
       expect(contactService.createContact).toHaveBeenCalledWith(
         'some-token',
         'Fred Bloggs',
@@ -193,24 +184,24 @@ describe('CreateContactByPrisonerNameController', () => {
       )
     })
 
-    it('should redirect to create-new-contact given new contact is validated but prison address is not resolved', async () => {
+    it('should redirect to create-new-contact if there is an error adding the recipient', async () => {
       req.body = {
         prisonerSob: '01-01-1990',
         prisonId: 'SKI',
       }
       req.session.recipientForm = { prisonerName: 'Fred Bloggs' }
       mockNewContactValidator.mockReturnValue([])
-      prisonRegisterService.getPrisonAddress.mockRejectedValue(new Error(`PrisonAddress for prison SKI not found`))
+      recipientFormService.addRecipient.mockRejectedValue('some-error')
 
       await createContactController.submitCreateNewContact(req as unknown as Request, res as unknown as Response)
 
       expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient/create-new-contact/by-prisoner-name')
       expect(req.flash).toHaveBeenCalledWith('errors', [
-        { href: 'prisonId', text: 'There was a problem getting the address for the selected prison' },
+        { href: 'prisonId', text: 'There was a problem adding your new recipient. Please try again.' },
       ])
     })
 
-    it('should redirect to create-new-contact given new contact is not validated', async () => {
+    it('should redirect to create-new-contact given new contact is invalid', async () => {
       req.body = { prisonerDob: '01-01-1990', prisonId: '' }
       req.session.recipientForm = { prisonerName: 'John Smith' }
       mockNewContactValidator.mockReturnValue([{ href: '#prisonId', text: 'Select a prison name' }])
@@ -221,15 +212,15 @@ describe('CreateContactByPrisonerNameController', () => {
       expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient/create-new-contact/by-prisoner-name')
     })
 
-    it('should redirect to find-recipient given no recipientForm in the session', async () => {
-      req.session.recipientForm = undefined
+    it('should redirect if requires name', async () => {
+      recipientFormService.requiresName.mockReturnValue('some-redirect')
 
-      await createContactController.submitCreateNewContact(req as unknown as Request, res as unknown as Response)
+      await createContactController.getCreateNewContact(req as unknown as Request, res as unknown as Response)
 
-      expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient')
+      expect(res.redirect).toHaveBeenCalledWith('some-redirect')
     })
 
-    it(`should ignore if we couldn't create the contact for any reason`, async () => {
+    it("should ignore if we couldn't create the contact for any reason", async () => {
       req.body = {
         prisonerDob: undefined,
         'prisonerDob-day': '1',
@@ -240,26 +231,12 @@ describe('CreateContactByPrisonerNameController', () => {
       req.session.recipientForm = { prisonerName: 'Fred Bloggs' }
       req.session.slmToken = 'some-token'
       mockNewContactValidator.mockReturnValue([])
-      const prisonAddress: PrisonAddress = {
-        agencyCode: 'CKI',
-        agyDescription: 'Cookham Wood (YOI)',
-        flat: null,
-        premise: 'HMP COOKHAM WOOD',
-        street: null,
-        locality: null,
-        countyCode: 'KENT',
-        area: 'Rochester Kent',
-        postalCode: 'ME1 3LU',
-      }
-      prisonRegisterService.getPrisonAddress.mockResolvedValue(prisonAddress)
-      contactService.createContact.mockRejectedValue(new Error('Some error creating the contact'))
-      const expectedRecipients = [{ prisonAddress, prisonerDob: new Date(1990, 0, 1), prisonerName: 'Fred Bloggs' }]
+      contactService.createContact.mockRejectedValue('some-error')
 
       await createContactController.submitCreateNewContact(req as unknown as Request, res as unknown as Response)
 
       expect(res.redirect).toHaveBeenCalledWith('/barcode/review-recipients')
-      expect(req.session.recipients).toEqual(expectedRecipients)
-      expect(req.session.recipientForm).toBeUndefined()
+      expect(recipientFormService.addRecipient).toHaveBeenCalledWith(expect.anything())
       expect(req.session.createNewContactByPrisonerNameForm).toBeUndefined()
       expect(contactService.createContact).toHaveBeenCalledWith(
         'some-token',

--- a/server/routes/barcode/recipients/FindRecipientController.test.ts
+++ b/server/routes/barcode/recipients/FindRecipientController.test.ts
@@ -3,6 +3,7 @@ import { SessionData } from 'express-session'
 import FindRecipientController from './FindRecipientController'
 import prisonNumberValidator from '../validators/prisonNumberValidator'
 import prisonerNameValidator from '../validators/prisonerNameValidator'
+import RecipientFormService from './RecipientFormService'
 
 jest.mock('../validators/prisonNumberValidator')
 jest.mock('../validators/prisonerNameValidator')
@@ -17,10 +18,15 @@ const res = {
   redirect: jest.fn(),
 }
 
+const recipientFormService = {
+  resetForm: jest.fn(),
+}
+
 describe('FindRecipientController', () => {
-  const findRecipientController = new FindRecipientController()
+  const findRecipientController = new FindRecipientController(recipientFormService as unknown as RecipientFormService)
 
   afterEach(() => {
+    recipientFormService.resetForm.mockReset()
     res.render.mockReset()
     res.redirect.mockReset()
     req.session = {} as SessionData
@@ -61,19 +67,6 @@ describe('FindRecipientController', () => {
       await findRecipientController.submitFindByPrisonNumber(req as unknown as Request, res as unknown as Response)
 
       expect(req.session.recipientForm.prisonNumber).toEqual('A1234BC')
-    })
-  })
-
-  describe('getFindByPrisonerName', () => {
-    it('should clear down the recipient form', async () => {
-      req.session.recipientForm = { prisonNumber: 'A1234BC' }
-
-      await findRecipientController.getFindRecipientByPrisonerNameView(
-        req as unknown as Request,
-        res as unknown as Response
-      )
-
-      expect(req.session.recipientForm).toEqual({})
     })
   })
 

--- a/server/routes/barcode/recipients/FindRecipientController.test.ts
+++ b/server/routes/barcode/recipients/FindRecipientController.test.ts
@@ -10,7 +10,7 @@ jest.mock('../validators/prisonerNameValidator')
 const req = {
   session: {} as SessionData,
   flash: jest.fn(),
-  body: { prisonNumber: '', prisonerName: '' },
+  body: {},
 }
 const res = {
   render: jest.fn(),
@@ -34,6 +34,8 @@ describe('FindRecipientController', () => {
     })
 
     it('should redirect to create-new-contact given prison number is validated', async () => {
+      req.session.recipientForm = {}
+      req.body = { prisonNumber: 'A1234BC' }
       mockPrisonNumberValidator.mockReturnValue([])
 
       await findRecipientController.submitFindByPrisonNumber(req as unknown as Request, res as unknown as Response)
@@ -42,6 +44,7 @@ describe('FindRecipientController', () => {
     })
 
     it('should redirect to find-recipient/by-prison-number given prison number is validated', async () => {
+      req.session.recipientForm = {}
       mockPrisonNumberValidator.mockReturnValue(['Enter a prison number'])
 
       await findRecipientController.submitFindByPrisonNumber(req as unknown as Request, res as unknown as Response)
@@ -51,25 +54,26 @@ describe('FindRecipientController', () => {
     })
 
     it('should uppercase and trim the prison number', async () => {
-      req.body.prisonNumber = ' a1234bc '
+      req.session.recipientForm = {}
+      req.body = { prisonNumber: ' a1234bc ' }
       mockPrisonNumberValidator.mockReturnValue([])
 
       await findRecipientController.submitFindByPrisonNumber(req as unknown as Request, res as unknown as Response)
 
-      expect(req.body.prisonNumber).toEqual('A1234BC')
+      expect(req.session.recipientForm.prisonNumber).toEqual('A1234BC')
     })
   })
 
-  describe('submitFindByPrisonerName', () => {
-    it('should clear down the prison number form', async () => {
-      req.session.findRecipientByPrisonNumberForm = { prisonNumber: 'A1234BC' }
+  describe('getFindByPrisonerName', () => {
+    it('should clear down the recipient form', async () => {
+      req.session.recipientForm = { prisonNumber: 'A1234BC' }
 
       await findRecipientController.getFindRecipientByPrisonerNameView(
         req as unknown as Request,
         res as unknown as Response
       )
 
-      expect(req.session.findRecipientByPrisonNumberForm).toBeUndefined()
+      expect(req.session.recipientForm).toEqual({})
     })
   })
 
@@ -80,7 +84,9 @@ describe('FindRecipientController', () => {
       mockPrisonerNameValidator = prisonerNameValidator as jest.MockedFunction<typeof prisonerNameValidator>
     })
 
-    it('should redirect to create-new-contact given prison number is validated', async () => {
+    it('should redirect to create-new-contact given prisoner name is validated', async () => {
+      req.session.recipientForm = {}
+      req.body = { prisonerName: 'John Smith' }
       mockPrisonerNameValidator.mockReturnValue([])
 
       await findRecipientController.submitFindByPrisonerName(req as unknown as Request, res as unknown as Response)
@@ -89,6 +95,7 @@ describe('FindRecipientController', () => {
     })
 
     it('should redirect to find-recipient/by-prisoner-name given prisoner name is validated', async () => {
+      req.session.recipientForm = {}
       mockPrisonerNameValidator.mockReturnValue(['Enter a prisoner name'])
 
       await findRecipientController.submitFindByPrisonerName(req as unknown as Request, res as unknown as Response)
@@ -98,12 +105,13 @@ describe('FindRecipientController', () => {
     })
 
     it('should trim the prisoner name', async () => {
-      req.body.prisonerName = ' John Smith '
+      req.session.recipientForm = {}
+      req.body = { prisonerName: ' John Smith ' }
       mockPrisonerNameValidator.mockReturnValue([])
 
       await findRecipientController.submitFindByPrisonerName(req as unknown as Request, res as unknown as Response)
 
-      expect(req.body.prisonerName).toEqual('John Smith')
+      expect(req.session.recipientForm.prisonerName).toEqual('John Smith')
     })
   })
 })

--- a/server/routes/barcode/recipients/FindRecipientController.ts
+++ b/server/routes/barcode/recipients/FindRecipientController.ts
@@ -7,6 +7,7 @@ import formatErrors from '../../errorFormatter'
 
 export default class FindRecipientController {
   async getFindRecipientByPrisonNumberView(req: Request, res: Response): Promise<void> {
+    req.session.recipientForm = {}
     const view = new FindRecipientByPrisonNumberView(
       req.session?.findRecipientByPrisonNumberForm || {},
       req.flash('errors')
@@ -23,12 +24,14 @@ export default class FindRecipientController {
       return res.redirect('/barcode/find-recipient/by-prison-number')
     }
 
-    // TODO - lookup contact by prison number and redirect to appropriate endpoint
+    // TODO SLM-121 - lookup contact by prison number and redirect to either create new contact by prison number or review recipients
+    req.session.recipientForm.prisonNumber = req.session.findRecipientByPrisonNumberForm.prisonNumber
+    req.session.findRecipientByPrisonNumberForm = undefined
     return res.redirect('/barcode/find-recipient/create-new-contact/by-prison-number')
   }
 
   async getFindRecipientByPrisonerNameView(req: Request, res: Response): Promise<void> {
-    req.session.findRecipientByPrisonNumberForm = undefined
+    req.session.recipientForm = {}
     const view = new FindRecipientByPrisonerNameView(
       req.session?.findRecipientByPrisonerNameForm || {},
       req.flash('errors')
@@ -45,6 +48,9 @@ export default class FindRecipientController {
       return res.redirect('/barcode/find-recipient/by-prisoner-name')
     }
 
+    // TODO SLM-62 - find contacts by name and redirect to either choose contact or review recipients (save contacts on recipientForm if found!)
+    req.session.recipientForm.prisonerName = req.session.findRecipientByPrisonerNameForm.prisonerName
+    req.session.findRecipientByPrisonerNameForm = undefined
     return res.redirect('/barcode/find-recipient/create-new-contact/by-prisoner-name')
   }
 }

--- a/server/routes/barcode/recipients/FindRecipientController.ts
+++ b/server/routes/barcode/recipients/FindRecipientController.ts
@@ -4,10 +4,13 @@ import FindRecipientByPrisonerNameView from './FindRecipientByPrisonerNameView'
 import validatePrisonNumber from '../validators/prisonNumberValidator'
 import validatePrisonerName from '../validators/prisonerNameValidator'
 import formatErrors from '../../errorFormatter'
+import RecipientFormService from './RecipientFormService'
 
 export default class FindRecipientController {
+  constructor(private readonly recipientFormService: RecipientFormService) {}
+
   async getFindRecipientByPrisonNumberView(req: Request, res: Response): Promise<void> {
-    req.session.recipientForm = {}
+    this.recipientFormService.resetForm(req)
     const view = new FindRecipientByPrisonNumberView(
       req.session?.findRecipientByPrisonNumberForm || {},
       req.flash('errors')
@@ -31,7 +34,7 @@ export default class FindRecipientController {
   }
 
   async getFindRecipientByPrisonerNameView(req: Request, res: Response): Promise<void> {
-    req.session.recipientForm = {}
+    this.recipientFormService.resetForm(req)
     const view = new FindRecipientByPrisonerNameView(
       req.session?.findRecipientByPrisonerNameForm || {},
       req.flash('errors')

--- a/server/routes/barcode/recipients/RecipientFormService.test.ts
+++ b/server/routes/barcode/recipients/RecipientFormService.test.ts
@@ -1,0 +1,225 @@
+import { Request } from 'express'
+import { SessionData } from 'express-session'
+import type { Contact } from 'sendLegalMailApiClient'
+import type { PrisonAddress } from 'prisonTypes'
+import type { RecipientForm } from 'forms'
+import moment from 'moment'
+import RecipientFormService from './RecipientFormService'
+import PrisonRegisterService from '../../../services/prison/PrisonRegisterService'
+
+const req = {
+  session: {} as SessionData,
+}
+
+const prisonRegisterService = {
+  getPrisonAddress: jest.fn(),
+}
+
+const aContact = (): Contact => {
+  return {
+    id: 1,
+    prisonerName: 'John Smith',
+    prisonId: 'LEI',
+    prisonNumber: 'A1234BC',
+  }
+}
+
+const aContactDob = (): Contact => {
+  return {
+    id: 1,
+    prisonerName: 'John Smith',
+    prisonId: 'LEI',
+    dob: '1990-01-01',
+  }
+}
+
+const aPrisonAddress = (): PrisonAddress => {
+  return {
+    premise: 'HMP Leeds',
+  }
+}
+
+const aRecipientForm = (): RecipientForm => {
+  return {
+    prisonerName: 'John Smith',
+    prisonNumber: 'A1234BC',
+    prisonId: 'LEI',
+  }
+}
+
+const aRecipientDobForm = (): RecipientForm => {
+  return {
+    prisonerName: 'John Smith',
+    prisonerDob: moment('1990-01-01', 'YYYY-MM-DD').toDate(),
+    prisonId: 'LEI',
+  }
+}
+describe('Recipient Form Service', () => {
+  let recipientFormService: RecipientFormService
+
+  beforeEach(() => {
+    recipientFormService = new RecipientFormService(prisonRegisterService as unknown as PrisonRegisterService)
+  })
+
+  afterEach(() => {
+    prisonRegisterService.getPrisonAddress.mockReset()
+    req.session = {} as SessionData
+  })
+
+  describe('requiresName', () => {
+    it('should return redirect if no form', () => {
+      expect(recipientFormService.requiresName(req as unknown as Request)).toBeTruthy()
+    })
+
+    it('should return redirect if no prisoner name', () => {
+      req.session.recipientForm = {}
+
+      expect(recipientFormService.requiresName(req as unknown as Request)).toBeTruthy()
+    })
+
+    it('should return redirect if empty prisoner name', () => {
+      req.session.recipientForm = { prisonerName: '' }
+
+      expect(recipientFormService.requiresName(req as unknown as Request)).toBeTruthy()
+    })
+
+    it('should not return redirect if prisoner name', () => {
+      req.session.recipientForm = { prisonerName: 'John Smith' }
+
+      expect(recipientFormService.requiresName(req as unknown as Request)).toBeUndefined()
+    })
+  })
+
+  describe('requiresPrisonNumber', () => {
+    it('should return redirect if no form', () => {
+      expect(recipientFormService.requiresPrisonNumber(req as unknown as Request)).toBeTruthy()
+    })
+
+    it('should return redirect if no prison number', () => {
+      req.session.recipientForm = {}
+
+      expect(recipientFormService.requiresPrisonNumber(req as unknown as Request)).toBeTruthy()
+    })
+
+    it('should return redirect if empty prisoner name', () => {
+      req.session.recipientForm = { prisonNumber: '' }
+
+      expect(recipientFormService.requiresPrisonNumber(req as unknown as Request)).toBeTruthy()
+    })
+
+    it('should not return redirect if prisoner name', () => {
+      req.session.recipientForm = { prisonNumber: 'A1234BC' }
+
+      expect(recipientFormService.requiresPrisonNumber(req as unknown as Request)).toBeUndefined()
+    })
+  })
+
+  describe('requiresContacts', () => {
+    it('should return redirect if no form', () => {
+      expect(recipientFormService.requiresContacts(req as unknown as Request)).toBeTruthy()
+    })
+
+    it('should return redirect if no contacts', () => {
+      req.session.recipientForm = {}
+
+      expect(recipientFormService.requiresContacts(req as unknown as Request)).toBeTruthy()
+    })
+
+    it('should return redirect if empty contacts', () => {
+      req.session.recipientForm = { contacts: [] }
+
+      expect(recipientFormService.requiresContacts(req as unknown as Request)).toBeTruthy()
+    })
+
+    it('should not return redirect if contacts exist', () => {
+      req.session.recipientForm = { contacts: [aContact()] }
+
+      expect(recipientFormService.requiresContacts(req as unknown as Request)).toBeUndefined()
+    })
+  })
+
+  describe('addRecipient', () => {
+    it('should add the passed recipient to the saved list', async () => {
+      prisonRegisterService.getPrisonAddress.mockReturnValue(aPrisonAddress())
+      const recipient = aRecipientForm()
+
+      await recipientFormService.addRecipient(req as unknown as Request, recipient)
+
+      expect(req.session.recipients[0]).toEqual({
+        prisonNumber: 'A1234BC',
+        prisonerName: 'John Smith',
+        prisonAddress: aPrisonAddress(),
+      })
+      expect(req.session.recipientForm).toStrictEqual({})
+      expect(prisonRegisterService.getPrisonAddress).toHaveBeenCalledWith('LEI')
+    })
+
+    it('should add a recipient from the session to the saved list', async () => {
+      prisonRegisterService.getPrisonAddress.mockReturnValue(aPrisonAddress())
+      req.session.recipientForm = aRecipientForm()
+
+      await recipientFormService.addRecipient(req as unknown as Request)
+
+      expect(req.session.recipients[0]).toEqual({
+        prisonNumber: 'A1234BC',
+        prisonerName: 'John Smith',
+        prisonAddress: aPrisonAddress(),
+      })
+    })
+
+    it('should add a recipient with DOB to the saved list', async () => {
+      prisonRegisterService.getPrisonAddress.mockReturnValue(aPrisonAddress())
+      req.session.recipientForm = aRecipientDobForm()
+
+      await recipientFormService.addRecipient(req as unknown as Request)
+
+      expect(req.session.recipients[0]).toEqual({
+        prisonerName: 'John Smith',
+        prisonerDob: moment('1990-01-01', 'YYYY-MM-DD').toDate(),
+        prisonAddress: aPrisonAddress(),
+      })
+    })
+
+    it('should throw errors from retrieving the prison address', async () => {
+      prisonRegisterService.getPrisonAddress.mockRejectedValue('some-error')
+      req.session.recipientForm = aRecipientForm()
+
+      try {
+        await recipientFormService.addRecipient(req as unknown as Request)
+        fail('Expected any errors to be thrown')
+      } catch (error) {
+        expect(error).toStrictEqual('some-error')
+      }
+    })
+  })
+
+  describe('addContact', () => {
+    it('should save contact to recipient list', async () => {
+      prisonRegisterService.getPrisonAddress.mockReturnValue(aPrisonAddress())
+
+      await recipientFormService.addContact(req as unknown as Request, aContact())
+
+      expect(req.session.recipients[0]).toEqual({
+        prisonNumber: 'A1234BC',
+        prisonerName: 'John Smith',
+        prisonAddress: aPrisonAddress(),
+      })
+      expect(req.session.recipientForm).toStrictEqual({})
+      expect(prisonRegisterService.getPrisonAddress).toHaveBeenCalledWith('LEI')
+    })
+
+    it('should save contact with DoB to recipient list', async () => {
+      prisonRegisterService.getPrisonAddress.mockReturnValue(aPrisonAddress())
+
+      await recipientFormService.addContact(req as unknown as Request, aContactDob())
+
+      expect(req.session.recipients[0]).toEqual({
+        prisonerDob: moment('1990-01-01', 'YYYY-MM-DD').toDate(),
+        prisonerName: 'John Smith',
+        prisonAddress: aPrisonAddress(),
+      })
+      expect(req.session.recipientForm).toStrictEqual({})
+      expect(prisonRegisterService.getPrisonAddress).toHaveBeenCalledWith('LEI')
+    })
+  })
+})

--- a/server/routes/barcode/recipients/RecipientFormService.ts
+++ b/server/routes/barcode/recipients/RecipientFormService.ts
@@ -1,0 +1,65 @@
+import { Request } from 'express'
+import type { Recipient } from 'prisonTypes'
+import type { Contact } from 'sendLegalMailApiClient'
+import moment from 'moment'
+import type { RecipientForm } from 'forms'
+import PrisonRegisterService from '../../../services/prison/PrisonRegisterService'
+
+export default class RecipientFormService {
+  constructor(private readonly prisonRegisterService: PrisonRegisterService) {}
+
+  resetForm(req: Request) {
+    req.session.recipientForm = {}
+  }
+
+  requiresName(req: Request): string | undefined {
+    if ((req.session.recipientForm?.prisonerName?.trim() ?? '') === '') {
+      return '/barcode/find-recipient'
+    }
+    return undefined
+  }
+
+  requiresPrisonNumber(req: Request): string | undefined {
+    if ((req.session.recipientForm?.prisonNumber?.trim() ?? '') === '') {
+      return '/barcode/find-recipient/by-prison-number'
+    }
+    return undefined
+  }
+
+  requiresContacts(req: Request): string | undefined {
+    if ((req.session.recipientForm?.contacts ?? []).length === 0) {
+      return '/barcode/find-recipient/by-prisoner-name'
+    }
+    return undefined
+  }
+
+  async addRecipient(req: Request, recipientForm: RecipientForm = req.session.recipientForm) {
+    if (!req.session.recipients) {
+      req.session.recipients = []
+    }
+    const prisonAddress = await this.prisonRegisterService.getPrisonAddress(recipientForm.prisonId)
+    const newRecipient: Recipient = {
+      prisonerName: recipientForm.prisonerName || '',
+      prisonNumber: recipientForm.prisonNumber,
+      prisonerDob: recipientForm.prisonerDob,
+      prisonAddress,
+    }
+
+    req.session.recipients.push(newRecipient)
+    req.session.recipientForm = {}
+  }
+
+  async addContact(req: Request, contact: Contact) {
+    const recipientForm = await this.createRecipientForm(contact)
+    await this.addRecipient(req, recipientForm)
+  }
+
+  private async createRecipientForm(contact: Contact): Promise<RecipientForm> {
+    return {
+      prisonNumber: contact.prisonNumber,
+      prisonerName: contact.prisonerName,
+      prisonerDob: contact.dob ? moment(contact.dob, 'YYYY-MM-DD').toDate() : undefined,
+      prisonId: contact.prisonId,
+    } as RecipientForm
+  }
+}


### PR DESCRIPTION
* Use a hidden RecipientForm to collect all recipient details between pages
* Hide all pages from each other
* Add a service for common RecipientForm functionality
* Refactor everything to use the new RecipientFormService
* And some readme updates