### PR TITLE
SLM-20 Need lax cookie sameSite policy for email links

### DIFF
--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -21,7 +21,7 @@ export default function setUpWebSession(): Router {
   router.use(
     session({
       store: new RedisStore({ client }),
-      cookie: { secure: config.https, sameSite: 'strict', maxAge: config.session.expiryMinutes * 60 * 1000 },
+      cookie: { secure: config.https, sameSite: 'lax', maxAge: config.session.expiryMinutes * 60 * 1000 },
       secret: config.session.secret,
       resave: false, // redis implements touch so shouldn't need this
       saveUninitialized: false,

--- a/server/routes/cookies/CookiesPolicyController.test.ts
+++ b/server/routes/cookies/CookiesPolicyController.test.ts
@@ -153,7 +153,7 @@ describe('CookiesPolicyController', () => {
       expect(res.cookie).toHaveBeenCalledWith(
         'cookies_policy',
         'accept',
-        expect.objectContaining({ sameSite: 'strict', secure: true })
+        expect.objectContaining({ sameSite: 'lax', secure: true })
       )
     })
 

--- a/server/routes/cookies/CookiesPolicyController.ts
+++ b/server/routes/cookies/CookiesPolicyController.ts
@@ -39,7 +39,7 @@ export default class CookiesPolicyController {
       return res
         .cookie('cookies_policy', req.body.cookies, {
           maxAge: 365 * 24 * 60 * 60 * 1000,
-          sameSite: 'strict',
+          sameSite: 'lax',
           secure: true,
         })
         .redirect(`${redirectUrl}?showCookieConfirmation=true`)


### PR DESCRIPTION
If you set the cookie sameSite policy to strict then when you click on the email link to sign in via CJSM it doesn't pull cookies through - this means the session and cookie policy are lost and the email link doesn't work.

Needs a little more investigation to make sure this works when opening the link in a different browser.