### PR TITLE
SLM-153: Authentication & Authorisation for contact helpdesk; AuthError page

### DIFF
--- a/integration_tests/integration/helpdesk/contactHelpdelpdesk.spec.ts
+++ b/integration_tests/integration/helpdesk/contactHelpdelpdesk.spec.ts
@@ -3,6 +3,7 @@ import Page from '../../pages/page'
 import ScanBarcodePage from '../../pages/scan/scanBarcode'
 import ContactHelpdeskPage from '../../pages/helpdesk/contactHelpdesk'
 import ContactHelpdeskConfirmationPage from '../../pages/helpdesk/contactHelpdeskConfirmation'
+import AuthorisationErrorPage from '../../pages/authorisationError'
 
 context('Contact Helpdesk', () => {
   let contactHelpdeskPage: ContactHelpdeskPage
@@ -53,5 +54,23 @@ context('Contact Helpdesk', () => {
           .hasErrorContaining('email address')
       })
     })
+  })
+
+  it('should display authError page given unauthenticated user', () => {
+    cy.task('reset')
+    cy.visit('/scan-barcode/contact-helpdesk', { failOnStatusCode: false })
+
+    Page.verifyOnPage(AuthorisationErrorPage)
+  })
+
+  it('should display authError page given authenticated user without any of the SLM roles', () => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+    cy.signIn()
+
+    cy.visit('/scan-barcode/contact-helpdesk', { failOnStatusCode: false })
+
+    Page.verifyOnPage(AuthorisationErrorPage)
   })
 })

--- a/integration_tests/pages/authorisationError.ts
+++ b/integration_tests/pages/authorisationError.ts
@@ -2,6 +2,6 @@ import Page from './page'
 
 export default class AuthorisationErrorPage extends Page {
   constructor() {
-    super('auth-error')
+    super('auth-error', { expectHelpdeskLink: false })
   }
 }

--- a/server/middleware/authorisationMiddleware.test.ts
+++ b/server/middleware/authorisationMiddleware.test.ts
@@ -17,7 +17,7 @@ function createToken(authorities: string[]) {
 }
 
 describe('authorisationMiddleware', () => {
-  let req: Request
+  const req = { originalUrl: '/some/route' } as unknown as Request
   const next = jest.fn()
 
   function createResWithToken({ authorities }: { authorities: string[] }): Response {

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -9,13 +9,14 @@ export default function authorisationMiddleware(authorisedRoles: string[] = []):
       const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
 
       if (authorisedRoles.length && !roles.some(role => authorisedRoles.includes(role))) {
-        logger.error('User is not authorised to access this')
+        logger.error(`User is not authorised to access ${req.originalUrl}. Redirect to authError`)
         return res.redirect('/authError')
       }
 
       return next()
     }
 
+    logger.error(`User is not authenticated, cannot access ${req.originalUrl}. Redirect to sign-in`)
     req.session.returnTo = req.originalUrl
     return res.redirect('/sign-in')
   }

--- a/server/middleware/helpdesk/contactHelpdeskAuthorisationMiddleware.test.ts
+++ b/server/middleware/helpdesk/contactHelpdeskAuthorisationMiddleware.test.ts
@@ -1,0 +1,67 @@
+import { Request, Response } from 'express'
+import jwt from 'jsonwebtoken'
+import contactHelpdeskAuthorisationMiddleware from './contactHelpdeskAuthorisationMiddleware'
+
+function createToken(authorities: string[]) {
+  const payload = {
+    user_name: 'USER1',
+    scope: ['read', 'write'],
+    auth_source: 'nomis',
+    authorities,
+    jti: 'a610a10-cca6-41db-985f-e87efb303aaf',
+    client_id: 'clientid',
+  }
+
+  return jwt.sign(payload, 'secret', { expiresIn: '1h' })
+}
+
+describe('contactHelpdeskAuthorisationMiddleware', () => {
+  const req = { originalUrl: '/scan-barcode/contact-helpdesk' } as unknown as Request
+  const next = jest.fn()
+
+  function createResWithToken({ authorities }: { authorities: string[] }): Response {
+    return {
+      locals: {
+        user: {
+          token: createToken(authorities),
+        },
+      },
+      redirect: (redirectUrl: string) => {
+        return redirectUrl
+      },
+    } as unknown as Response
+  }
+
+  function createUnauthenticatedRes(): Response {
+    return {
+      locals: {},
+      redirect: (redirectUrl: string) => {
+        return redirectUrl
+      },
+    } as unknown as Response
+  }
+
+  it('should return next given user has an authorised role', () => {
+    const res = createResWithToken({ authorities: ['SOME_REQUIRED_ROLE'] })
+
+    const authorisationResponse = contactHelpdeskAuthorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
+
+    expect(authorisationResponse).toEqual(next())
+  })
+
+  it('should redirect to authError given user has no authorised roles', () => {
+    const res = createResWithToken({ authorities: [] })
+
+    const authorisationResponse = contactHelpdeskAuthorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
+
+    expect(authorisationResponse).toEqual('/authError')
+  })
+
+  it('should redirect to authError given user is not authenticated', () => {
+    const res = createUnauthenticatedRes()
+
+    const authorisationResponse = contactHelpdeskAuthorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
+
+    expect(authorisationResponse).toEqual('/authError')
+  })
+})

--- a/server/middleware/helpdesk/contactHelpdeskAuthorisationMiddleware.ts
+++ b/server/middleware/helpdesk/contactHelpdeskAuthorisationMiddleware.ts
@@ -1,0 +1,22 @@
+import jwtDecode from 'jwt-decode'
+import { RequestHandler } from 'express'
+
+import logger from '../../../logger'
+
+export default function contactHelpdeskAuthorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {
+  return (req, res, next) => {
+    if (!res.locals.user?.token) {
+      logger.error(`User is not authenticated, cannot access ${req.originalUrl}. Redirect to authError`)
+      return res.redirect('/authError')
+    }
+
+    const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
+
+    if (authorisedRoles.length && !roles.some(role => authorisedRoles.includes(role))) {
+      logger.error(`User is not authorised to access ${req.originalUrl}. Redirect to authError`)
+      return res.redirect('/authError')
+    }
+
+    return next()
+  }
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -75,7 +75,11 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('renderChooseBarcodeOptionRadiosFilter', renderChooseBarcodeOptionRadiosFilter)
   njkEnv.addFilter('renderChooseContactRadiosFilter', renderChooseContactRadiosFilter)
 
-  njkEnv.addGlobal('contactHelpdeskBannerExcludedOnPages', ['contact-helpdesk', 'contact-helpdesk-submitted'])
+  njkEnv.addGlobal('contactHelpdeskBannerExcludedOnPages', [
+    'auth-error',
+    'contact-helpdesk',
+    'contact-helpdesk-submitted',
+  ])
   njkEnv.addGlobal('fileUploadsEnabled', config.fileUploadsEnabled)
 
   return njkEnv

--- a/server/views/autherror.njk
+++ b/server/views/autherror.njk
@@ -6,12 +6,14 @@
 
   <section class="app-container govuk-body">
 
-    <h1 class="govuk-heading-l">
-      Authorisation Error
-    </h1>
-    <p>
-      You are not authorised to use this application.
-    </p>
+    <div class="govuk-grid-row" id="scan-barcode-form">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Check Rule 39 mail</h1>
+
+        <p>You haven't been given access to the Check Rule 39 mail service yet.</p>
+        <p>Contact your local system administrator (LSA) to request access.</p>
+      </div>
+    </div>
 
   </section>
 


### PR DESCRIPTION
This PR sets up the authentication and authorisation rules for the `/scan-barcode/contact-helpdesk` route:

When requesting `scan-barcode/contact-helpdesk`:
* If you are not DPS authenticated at all, show the AuthError page
* If you are DPS authenticated but do not have either of the SLM roles, show the AuthError page

Also updated the markup of the AuthError page in line with the current design