### PR TITLE
SLM-133: Updated feedback banner content

### DIFF
--- a/server/views/layout.njk
+++ b/server/views/layout.njk
@@ -95,7 +95,7 @@
       tag: {
         text: "beta"
       },
-      html: 'This is a new service – your <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="'+ phaseBannerLink +'">feedback</a> will help us to improve it.'
+      html: 'Leave <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="'+ phaseBannerLink +'">feedback<span class="govuk-visually-hidden"> (opens in new tab)</span></a> to help us improve this new service.'
     }) }}
 
     <span class="govuk-visually-hidden" id="{{ pageId }}"></span>


### PR DESCRIPTION
Feedback banner content updated as required:
<img width="996" alt="Screenshot 2022-03-03 at 15 19 31" src="https://user-images.githubusercontent.com/94835226/156595129-ab911f4b-1902-4780-84ee-1e7f0ecb7dbd.png">

