### PR TITLE
SLM-175: Reset editContactForm when rendering review recipients page

### DIFF
--- a/integration_tests/integration/barcode/editContact.spec.ts
+++ b/integration_tests/integration/barcode/editContact.spec.ts
@@ -1,4 +1,5 @@
 import ReviewRecipientsPage from '../../pages/barcode/reviewRecipients'
+import Page from '../../pages/page'
 
 context('Edit contact details', () => {
   beforeEach(() => {
@@ -24,5 +25,25 @@ context('Edit contact details', () => {
     editContactPage.typeAheadAValidPrison('q').submitWithError().hasErrorContaining('prisonId', 'prison')
     reviewRecipientsPage = editContactPage.typeAheadAValidPrison('stocken').submit(1)
     reviewRecipientsPage.hasPrisonNamesExactly('HMP Stocken')
+  })
+
+  it('should reset form and errors when navigating back to review recipients then choosing to edit contact again', () => {
+    // Arrive on the edit contact page with no errors
+    let reviewRecipientsPage = ReviewRecipientsPage.goToPage()
+    let editContactPage = reviewRecipientsPage.editContact(1)
+    editContactPage.hasPrisonName('Ashfield (HMP)').hasNoErrors()
+
+    // make a change that results in a validation error
+    editContactPage.typeAheadAValidPrison('q').submitWithError().hasErrorContaining('prisonId', 'prison')
+
+    // click browser back to go back to Review Recipients
+    cy.go(-3)
+    reviewRecipientsPage = Page.verifyOnPage(ReviewRecipientsPage)
+
+    // edit the contact again
+    editContactPage = reviewRecipientsPage.editContact(1)
+
+    // assert the previous validation errors have been cleared and the prison name is from the original contact
+    editContactPage.hasPrisonName('Ashfield (HMP)').hasNoErrors()
   })
 })

--- a/server/routes/barcode/review/ReviewRecipientsController.test.ts
+++ b/server/routes/barcode/review/ReviewRecipientsController.test.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express'
 import { SessionData } from 'express-session'
+import moment from 'moment'
 import ReviewRecipientsController from './ReviewRecipientsController'
 
 const req = {
@@ -11,6 +12,22 @@ const req = {
 const res = {
   render: jest.fn(),
   redirect: jest.fn(),
+}
+
+const anEditContactForm = {
+  contactId: 1,
+  prisonerName: 'some-name',
+  prisonId: 'KTI',
+  prisonNumber: 'some-prison-number',
+  dob: moment('1990-01-19', 'YYYY-MM-DD').toDate(),
+  'dob-day': '19',
+  'dob-month': '1',
+  'dob-year': '1990',
+}
+const aRecipient = {
+  prisonerName: 'John Smith',
+  prisonNumber: 'A1234BC',
+  prisonAddress: { premise: 'HMP Somewhere', postalCode: 'AA1 1AA' },
 }
 
 describe('ReviewRecipientsController', () => {
@@ -35,6 +52,17 @@ describe('ReviewRecipientsController', () => {
       await reviewRecipientsController.getReviewRecipientsView(req as unknown as Request, res as unknown as Response)
 
       expect(res.redirect).toHaveBeenCalledWith('/barcode/find-recipient')
+    })
+
+    it('should render page having cleared editContactForm', async () => {
+      const recipients = [aRecipient]
+      req.session.recipients = recipients
+      req.session.editContactForm = anEditContactForm
+
+      await reviewRecipientsController.getReviewRecipientsView(req as unknown as Request, res as unknown as Response)
+
+      expect(res.render).toHaveBeenCalledWith('pages/barcode/review-recipients', { errors: [], recipients })
+      expect(req.session.editContactForm).toBeUndefined()
     })
   })
 

--- a/server/routes/barcode/review/ReviewRecipientsController.ts
+++ b/server/routes/barcode/review/ReviewRecipientsController.ts
@@ -6,6 +6,7 @@ export default class ReviewRecipientsController {
     if (!req.session.recipients) {
       return res.redirect('/barcode/find-recipient')
     }
+    req.session.editContactForm = undefined
 
     const view = new ReviewRecipientsView(req.session.recipients, req.flash('errors'))
     return res.render('pages/barcode/review-recipients', { ...view.renderArgs })


### PR DESCRIPTION
Fixes bug where validation errors and previous "edit contact form" state are not cleared/reset when using the browser back button and then editing the contact again