### PR TITLE
SLM-190 Support smoke test

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -39,6 +39,7 @@ declare module 'express-session' {
     contactHelpdeskForm: ContactHelpdeskForm
     editContactForm: EditContactForm
     msjSmokeTestUser: boolean
+    lsjSmokeTestUser: boolean
   }
 
   export interface CookiesPolicy {

--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -43,7 +43,7 @@ const authenticationMiddleware: AuthenticationMiddleware = (verifyToken, smokeTe
       }
     }
 
-    if (msjSecret && req.query['smoke-test']) {
+    if (msjSecret || req.query['smoke-test']) {
       await checkForSmokeTestRequest()
       if (req.session.msjSmokeTestUser) {
         configureMsjSmoketestUser()

--- a/server/routes/barcode/pdf/PdfController.ts
+++ b/server/routes/barcode/pdf/PdfController.ts
@@ -63,10 +63,16 @@ export default class PdfController {
     const filename = this.pdfFilename(numberOfCoversheets, this.envelopeSize(req.session.pdfForm))
     const { envelopeSize } = req.session.pdfForm
 
+    let smokeTestBarcode: string
+    if (req.session.lsjSmokeTestUser) {
+      smokeTestBarcode = req.session.pdfRecipients[0].barcodeValue
+    }
+
     return res.render('pages/barcode/pdf/print-coversheets', {
       envelopeSize,
       numberOfCoversheets,
       filename,
+      smokeTestBarcode,
     })
   }
 

--- a/server/routes/barcode/pdf/PdfController.ts
+++ b/server/routes/barcode/pdf/PdfController.ts
@@ -16,7 +16,7 @@ export default class PdfController {
       return res.redirect('/barcode/find-recipient')
     }
 
-    const view = new PdfControllerView(req.session.pdfForm || {}, req.flash('errors'))
+    const view = new PdfControllerView(req.session.pdfForm || {}, '', req.flash('errors'))
     return res.render('pages/barcode/pdf/select-envelope-size', { ...view.renderArgs })
   }
 

--- a/server/routes/barcode/pdf/PdfControllerView.ts
+++ b/server/routes/barcode/pdf/PdfControllerView.ts
@@ -14,17 +14,23 @@ export const ENVELOPE_SIZES: Array<EnvelopeSizeSpec> = [
 ]
 
 export default class PdfControllerView {
-  constructor(private readonly pdfForm: PdfForm, private readonly errors?: Array<Record<string, string>>) {}
+  constructor(
+    private readonly pdfForm: PdfForm,
+    private readonly smokeTestBarcode: string,
+    private readonly errors?: Array<Record<string, string>>
+  ) {}
 
   get renderArgs(): {
     form: PdfForm
     errors: Array<Record<string, string>>
     envelopeSizes: Array<EnvelopeSizeSpec>
+    smokeTestBarcode: string
   } {
     return {
       form: this.pdfForm,
       errors: this.errors || [],
       envelopeSizes: ENVELOPE_SIZES,
+      smokeTestBarcode: this.smokeTestBarcode,
     }
   }
 }

--- a/server/routes/link/RequestLinkController.ts
+++ b/server/routes/link/RequestLinkController.ts
@@ -19,8 +19,10 @@ export default class RequestLinkController {
   }
 
   async submitLinkRequest(req: Request, res: Response): Promise<void> {
+    req.session.lsjSmokeTestUser = false
     if (config.smoketest.lsjSecret && req.body.email === config.smoketest.lsjSecret) {
       req.query.secret = config.smoketest.lsjSecret
+      req.session.lsjSmokeTestUser = true
       return this.verifyLinkController.verifyLink(req, res)
     }
 

--- a/server/views/pages/barcode/pdf/print-coversheets.njk
+++ b/server/views/pages/barcode/pdf/print-coversheets.njk
@@ -59,6 +59,12 @@
         <a href="/barcode/find-recipient" data-qa="send-more-legal-mail" class="govuk-link">Enter another prison number</a>
       </div>
     </div>
+
+    {% if smokeTestBarcode %}
+    <div class="govuk-visually-hidden">
+      <p data-qa='smoke-test-barcode'>{{ smokeTestBarcode }}</p>
+    </div>
+    {% endif %}
   </section>
 
 {% endblock %}


### PR DESCRIPTION
Add barcopde number to screen when running the LSJ smoketest so it can be used in the LSJ smoketest.