### PR TITLE
SLM-231: Set OTC feature flag to get tests running consistently

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -7,3 +7,4 @@ ZENDESK_API_URL=http://localhost:9091/zendesk
 NODE_ENV=development
 API_CLIENT_ID=clientid
 API_CLIENT_SECRET=clientsecret
+ONE_TIME_CODE_AUTH_ENABLED=false

--- a/server/routes/fixtures/SuperTestWrapper.ts
+++ b/server/routes/fixtures/SuperTestWrapper.ts
@@ -6,6 +6,7 @@ import express from 'express'
 import app from '../../index'
 import config from '../../config'
 import mockHmppsAuth from './mock-hmpps-auth'
+import legalSenderJourneyAuthenticationStartPage from '../../middleware/legalSenderJourneyAuthenticationStartPage'
 
 jest.mock('redis', () => jest.requireActual('redis-mock'))
 
@@ -15,6 +16,7 @@ export default class SuperTestWrapper {
   mockedSendLegalMailApi = nock(config.apis.sendLegalMail.url)
 
   constructor() {
+    config.featureFlags.lsjOneTimeCodeAuthEnabled = false
     const application: express.Application = app()
     this.request = request.agent(application)
     this.request //
@@ -33,7 +35,7 @@ export default class SuperTestWrapper {
 
   unauthenticated = async () => {
     mockHmppsAuth()
-    await this.request.get('/link/request-link?force=true') // log out legal sender user
+    await this.request.get(`${legalSenderJourneyAuthenticationStartPage()}?force=true`) // log out legal sender user
     nock.cleanAll()
   }
 


### PR DESCRIPTION
This PR fixes a couple of tests by forcing the One Time Code feature flag to be disabled.
This is necessary because at this stage of the development I have no tests for the One Time Code stuff that is dependant on the feature flag, but there are tests for the existing magic code auth approach that are now sensitive to the feature flag.

On my dev machine, where I am toggling the feature flag, the tests fail when I have left the feature flag on (ie. One Time Code enabled), so this change fixes that by forcing the flag off.

As and when the development for this One Time Code stuff matures we will write cypress and other SuperTest tests that properly test the journey with One Time Code enabled, but for the time being we can force it as disabled to keep the existing tests working