### PR TITLE
SLM-231: Fleshed out service call to submit email to request a one time code

### DIFF
--- a/server/routes/one-time-code-auth/RequestOneTimeCodeController.test.ts
+++ b/server/routes/one-time-code-auth/RequestOneTimeCodeController.test.ts
@@ -1,0 +1,141 @@
+import { Request, Response } from 'express'
+import type { SessionData } from 'express-session'
+import RequestOneTimeCodeController from './RequestOneTimeCodeController'
+import VerifyOneTimeCodeController from './VerifyOneTimeCodeController'
+import OneTimeCodeService from '../../services/one-time-code-auth/OneTimeCodeService'
+import config from '../../config'
+import validate from './RequestOneTimeCodeValidator'
+
+const req = {
+  session: {} as SessionData,
+  flash: jest.fn(),
+  body: {},
+  ip: '127.0.0.1',
+  sessionID: '12345678',
+}
+const res = {
+  render: jest.fn(),
+  redirect: jest.fn(),
+}
+
+const oneTimeCodeService = {
+  requestOneTimeCode: jest.fn(),
+}
+const verifyOneTimeCodeController = {
+  verifyOneTimeCode: jest.fn(),
+}
+
+jest.mock('../../config')
+jest.mock('./RequestOneTimeCodeValidator')
+
+describe('RequestOneTimeCodeController', () => {
+  const requestOneTimeCodeController = new RequestOneTimeCodeController(
+    oneTimeCodeService as unknown as OneTimeCodeService,
+    verifyOneTimeCodeController as unknown as VerifyOneTimeCodeController
+  )
+
+  beforeEach(() => {
+    config.oneTimeCodeValidityDuration = 10
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('getRequestOneTimeCodeView', () => {
+    it('should render view given no requestOneTimeCodeForm on the session', async () => {
+      req.session.requestOneTimeCodeForm = undefined
+
+      await requestOneTimeCodeController.getRequestOneTimeCodeView(
+        req as undefined as Request,
+        res as undefined as Response
+      )
+
+      expect(res.render).toHaveBeenCalledWith('pages/one-time-code-auth/requestOneTimeCode', {
+        errors: [],
+        form: {},
+        oneTimeCodeValidityDuration: 10,
+      })
+      expect(req.session.requestOneTimeCodeForm).toBeUndefined()
+    })
+
+    it('should render view given requestOneTimeCodeForm on the session and errors', async () => {
+      req.session.requestOneTimeCodeForm = { email: 'someone@aarvark.com' }
+      req.flash.mockReturnValue([{ href: '#email', text: 'Enter a valid email' }])
+
+      await requestOneTimeCodeController.getRequestOneTimeCodeView(
+        req as undefined as Request,
+        res as undefined as Response
+      )
+
+      expect(res.render).toHaveBeenCalledWith('pages/one-time-code-auth/requestOneTimeCode', {
+        errors: [{ href: '#email', text: 'Enter a valid email' }],
+        form: { email: 'someone@aarvark.com' },
+        oneTimeCodeValidityDuration: 10,
+      })
+      expect(req.session.requestOneTimeCodeForm).toBeUndefined()
+    })
+  })
+
+  describe('submitOneTimeCodeRequest', () => {
+    const mockRequestOneTimeCodeValidator = validate as jest.MockedFunction<typeof validate>
+
+    it('should redirect to email sent page given valid requestOneTimeCodeForm', async () => {
+      req.body = { email: 'someone@aarvark.com.cjsm.net' }
+      mockRequestOneTimeCodeValidator.mockReturnValue(true)
+      oneTimeCodeService.requestOneTimeCode.mockResolvedValue(undefined)
+
+      await requestOneTimeCodeController.submitOneTimeCodeRequest(
+        req as undefined as Request,
+        res as undefined as Response
+      )
+
+      expect(oneTimeCodeService.requestOneTimeCode).toHaveBeenCalledWith(
+        'someone@aarvark.com.cjsm.net',
+        '12345678',
+        '127.0.0.1'
+      )
+      expect(res.redirect).toHaveBeenCalledWith('email-sent')
+      expect(req.session.lsjSmokeTestUser).toBeFalsy()
+    })
+
+    it('should redirect to request code page given invalid requestOneTimeCodeForm', async () => {
+      req.body = { email: 'someone@aarvark.com' }
+      mockRequestOneTimeCodeValidator.mockReturnValue(false)
+
+      await requestOneTimeCodeController.submitOneTimeCodeRequest(
+        req as undefined as Request,
+        res as undefined as Response
+      )
+
+      expect(oneTimeCodeService.requestOneTimeCode).not.toHaveBeenCalled()
+      expect(res.redirect).toHaveBeenCalledWith('request-code')
+      expect(req.session.lsjSmokeTestUser).toBeFalsy()
+    })
+
+    it('should redirect to request code page with errors given service fails', async () => {
+      req.body = { email: 'someone@aarvark.com.cjsm.net' }
+      mockRequestOneTimeCodeValidator.mockReturnValue(true)
+      oneTimeCodeService.requestOneTimeCode.mockRejectedValue({ status: 503 })
+
+      await requestOneTimeCodeController.submitOneTimeCodeRequest(
+        req as undefined as Request,
+        res as undefined as Response
+      )
+
+      expect(oneTimeCodeService.requestOneTimeCode).toHaveBeenCalledWith(
+        'someone@aarvark.com.cjsm.net',
+        '12345678',
+        '127.0.0.1'
+      )
+      expect(res.redirect).toHaveBeenCalledWith('request-code')
+      expect(req.flash).toHaveBeenCalledWith('errors', [
+        {
+          href: '#email',
+          text: 'There was an error generating your sign in code. Try again to request a new one to sign in.',
+        },
+      ])
+      expect(req.session.lsjSmokeTestUser).toBeFalsy()
+    })
+  })
+})

--- a/server/services/one-time-code-auth/OneTimeCodeService.test.ts
+++ b/server/services/one-time-code-auth/OneTimeCodeService.test.ts
@@ -1,0 +1,46 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import nock from 'nock'
+import HmppsAuthClient from '../../data/hmppsAuthClient'
+import config from '../../config'
+import TokenStore from '../../data/cache/TokenStore'
+import OneTimeCodeService from './OneTimeCodeService'
+
+jest.mock('../../data/hmppsAuthClient')
+
+describe('One Time Code Service', () => {
+  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+  let oneTimeCodeService: OneTimeCodeService
+  let mockedSendLegalMailApi: nock.Scope
+
+  beforeEach(() => {
+    mockedSendLegalMailApi = nock(config.apis.sendLegalMail.url)
+
+    hmppsAuthClient = new HmppsAuthClient({} as TokenStore) as jest.Mocked<HmppsAuthClient>
+    hmppsAuthClient.getSystemClientToken.mockResolvedValue('a-system-client-token')
+    oneTimeCodeService = new OneTimeCodeService(hmppsAuthClient)
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  describe('requestOneTimeCode', () => {
+    it('should request a one time code', done => {
+      mockedSendLegalMailApi.post('/oneTimeCode/email', { email: 'a.b@c.com', sessionID: '12345678' }).reply(201)
+
+      oneTimeCodeService.requestOneTimeCode('a.b@c.com', '12345678', '127.0.0.1').then(() => {
+        expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalled()
+        done()
+      })
+    })
+
+    it('should fail to request a one time code given getSystemClientToken fails', done => {
+      hmppsAuthClient.getSystemClientToken.mockRejectedValue('an error getting system client token')
+
+      oneTimeCodeService.requestOneTimeCode('a.b@c.com', '12345678', '127.0.0.1').catch(error => {
+        expect(error).toBe('an error getting system client token')
+        done()
+      })
+    })
+  })
+})

--- a/server/services/one-time-code-auth/OneTimeCodeService.ts
+++ b/server/services/one-time-code-auth/OneTimeCodeService.ts
@@ -1,3 +1,4 @@
+import type { OneTimeCodeRequest } from 'sendLegalMailApiClient'
 import HmppsAuthClient from '../../data/hmppsAuthClient'
 import RestClient from '../../data/restClient'
 import config from '../../config'
@@ -9,8 +10,14 @@ export default class OneTimeCodeService {
     return new RestClient('Send Legal Mail API Client', config.apis.sendLegalMail, hmppsToken, null, sourceIp)
   }
 
-  async requestOneTimeCode(_email: string, _sourceIp: string): Promise<unknown> {
-    return null
+  async requestOneTimeCode(email: string, sessionID: string, sourceIp: string): Promise<unknown> {
+    const oneTimeCodeRequest: OneTimeCodeRequest = { email, sessionID }
+    return this.hmppsAuthClient.getSystemClientToken().then(hmppsToken =>
+      OneTimeCodeService.restClient(hmppsToken, sourceIp).post({
+        path: `/oneTimeCode/email`,
+        data: oneTimeCodeRequest,
+      })
+    )
   }
 
   async verifyOneTimeCode(_secret: string, _sourceIp: string): Promise<string> {

--- a/server/views/pages/one-time-code-auth/emailSent.njk
+++ b/server/views/pages/one-time-code-auth/emailSent.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set pageTitle = applicationName + " - Sign in code email sent" %}
@@ -37,6 +38,35 @@
           type: 'success',
           html: html
         }) }}
+
+
+        <form id="code-form" action="verify-code" method="post" novalidate>
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+          {% call govukFieldset({ }) %}
+            {{ govukInput({
+              label: {
+                text: 'Enter the code from your email',
+                classes: 'govuk-label–s'
+              },
+              hint: {
+                text: 'For example, ABCD'
+              },
+              id: "code",
+              name: "code",
+              value: form.code,
+              spellcheck: false,
+              errorMessage: errors | findError('code')
+            }) }}
+            <div class="govuk-button-group">
+              {{ govukButton({
+                text: "Submit",
+                attributes: { 'data-qa': 'submit-code-button' }
+              }) }}
+            </div>
+          {% endcall %}
+
+        </form>
 
         <h2 class="govuk-heading-m">What to do if you don't get the code</h2>
         <p>Check that the:


### PR DESCRIPTION
PR that implements the method in `OneTimeCodeService` to call the API to submit the user's email address and request a one time code is generated and emailed to them.
Wired into the controller, and tests implemented