### PR TITLE
SLM-231: Smoke tests are now aware of and work with One Time Code

### DIFF
--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -10,5 +10,10 @@ declare namespace Cypress {
      * Custom command to sign in as a Legal Sender
      */
     signInAsLegalSender<S = unknown>(): Chainable<S>
+
+    /**
+     * Custom command to sign in as the smoke test environment Legal Sender
+     */
+    signInAsSmokeTestLegalSender<S = unknown>(): Chainable<S>
   }
 }

--- a/integration_tests/pages/barcode/printCoversheets.ts
+++ b/integration_tests/pages/barcode/printCoversheets.ts
@@ -29,7 +29,7 @@ export default class PrintCoversheetsPage extends Page {
 
   sendMoreLegalMailLink = (): PageElement => cy.get('[data-qa=send-more-legal-mail]')
 
-  smokeTestBarcode = (): PageElement => cy.get('p[data-qa=smoke-test-barcode]').invoke('text')
+  smokeTestBarcode = (): PageElement => cy.get('[data-qa=smoke-test-barcode]').invoke('text')
 
   static goToPage = (): PrintCoversheetsPage => SelectEnvelopeSizePage.goToPage().submitHavingSelectedDlEnvelopeSize()
 }

--- a/integration_tests/pages/one-time-code/requestOneTimeCode.ts
+++ b/integration_tests/pages/one-time-code/requestOneTimeCode.ts
@@ -1,17 +1,15 @@
 import Page, { PageElement } from '../page'
-// eslint-disable-next-line import/no-cycle
-import EmailSentPage from './emailSent'
 
 export default class RequestOneTimeCodePage extends Page {
   constructor() {
     super('request-one-time-code')
   }
 
-  submitFormWithValidEmailAddress = (email: string, expectNextPage = true): EmailSentPage | RequestOneTimeCodePage => {
+  submitFormWithValidEmailAddress<T>(T, email: string): T {
     this.emailField().type(email)
 
     this.submitButton().click()
-    return expectNextPage ? Page.verifyOnPage(EmailSentPage) : Page.verifyOnPage(RequestOneTimeCodePage)
+    return Page.verifyOnPage(T)
   }
 
   submitFormWithInvalidEmailAddress = (email: string): RequestOneTimeCodePage => {

--- a/integration_tests/smoke/smoke.spec.ts
+++ b/integration_tests/smoke/smoke.spec.ts
@@ -1,16 +1,13 @@
 import Page from '../pages/page'
-import RequestLinkPage from '../pages/link/requestLink'
 import ReviewRecipientsPage from '../pages/barcode/reviewRecipients'
 import generateRandomPrisonNumber from './prisonNumberGenerator'
 import IndexPage from '../pages'
+import FindRecipientByPrisonNumberPage from '../pages/barcode/findRecipientByPrisonNumber'
 
 context('Smoke test', () => {
   it('should create a barcode', () => {
-    cy.visit(`${Cypress.env('LSJ_URL')}/link/request-link`)
-    let requestLinkPage = Page.verifyOnPage(RequestLinkPage)
-    requestLinkPage = requestLinkPage.clickCookieAction(RequestLinkPage, 'reject')
-    requestLinkPage = requestLinkPage.clickCookieAction(RequestLinkPage, 'hide')
-    const findRecipientPage = requestLinkPage.submitFormWithSmokeTestUser(Cypress.env('APP_SMOKETEST_LSJSECRET'))
+    cy.signInAsSmokeTestLegalSender()
+    const findRecipientPage = Page.verifyOnPage(FindRecipientByPrisonNumberPage)
 
     const createContactPage = findRecipientPage //
       .submitWithPrisonNumber(generateRandomPrisonNumber())

--- a/server/views/pages/barcode/pdf/print-coversheets.njk
+++ b/server/views/pages/barcode/pdf/print-coversheets.njk
@@ -61,9 +61,7 @@
     </div>
 
     {% if smokeTestBarcode %}
-    <div class="govuk-visually-hidden">
-      <p data-qa='smoke-test-barcode'>{{ smokeTestBarcode }}</p>
-    </div>
+      <span class="govuk-!-display-none" data-qa="smoke-test-barcode">{{ smokeTestBarcode }}</span>
     {% endif %}
   </section>
 

--- a/smoke_tests/run-smoke-test.sh
+++ b/smoke_tests/run-smoke-test.sh
@@ -57,4 +57,12 @@ export CYPRESS_LSJ_URL=$LSJ_URL
 export CYPRESS_MSJ_URL=$MSJ_URL
 export CYPRESS_APP_SMOKETEST_MSJAUTHCODE=$(curl -XPOST $MSJ_URL/getSmokeTestSecret -H 'Content-Type: application/json' -d "{ \"msjSecret\": \"$MSJ_SECRET\" }" | jq -r '.token')
 
+# Determine whether the deployed environment that we are about to run the smoke tests against has OTC enabled or not
+# We can do that by making a GET request for the magic link page - if we get a 200 then magic link is enabled, else OTC is enabled
+if [ $(curl -XGET -s -o /dev/null -w "%{http_code}" $LSJ_URL/link/request-link) == 200 ]; then
+  export CYPRESS_ONE_TIME_CODE_AUTH_ENABLED=false
+else
+  export CYPRESS_ONE_TIME_CODE_AUTH_ENABLED=true
+fi
+
 $CYPRESS_EXE run


### PR DESCRIPTION
PR to make our smoke tests aware of whether the environment under test is configured for One Time Code or not, and authenticate as the Smoke Test Legal Sender using the appropriate screens.