### PR TITLE
SLM-195: Remove nulls from an address

### DIFF
--- a/server/services/barcode/CreateBarcodeService.test.ts
+++ b/server/services/barcode/CreateBarcodeService.test.ts
@@ -284,10 +284,11 @@ describe('CreateBarcodeService', () => {
       prisonNumber: 'A1234BC',
       prison: {
         id: 'BSI',
+        name: 'Somewhere (HMP)',
         addressName: 'HMP Somewhere',
         street: 'A Street',
         locality: 'Town',
-        postCode: 'SW1 1SW',
+        postalCode: 'SW1 1SW',
       },
     }
     it('should allow name of 30 characters or less', () => {
@@ -404,6 +405,23 @@ describe('CreateBarcodeService', () => {
       })
 
       expect(address[1]).toStrictEqual('01-01-1990')
+    })
+
+    it('should remove nulls if there are any in the address lines', () => {
+      const address = createBarcodeService.formatAddressContent({
+        prisonerName: 'John Smith',
+        prisonNumber: 'A1234BC',
+        prison: {
+          id: 'BSI',
+          name: 'Somewhere (HMP)',
+          addressName: 'HMP Somewhere',
+          street: null,
+          locality: null,
+          postalCode: 'SW1 1SW',
+        },
+      })
+
+      expect(address).toEqual(['John Smith', 'A1234BC', 'HMP Somewhere', 'SW1 1SW'])
     })
   })
 })

--- a/server/services/barcode/CreateBarcodeService.ts
+++ b/server/services/barcode/CreateBarcodeService.ts
@@ -151,7 +151,7 @@ export default class CreateBarcodeService {
         address.street,
         address.locality,
         address.postalCode
-      )
+      ).filter(addressLine => addressLine != null)
     }
     // Calculate how to split the name into 2 lines
     let name1length = Math.min(30, name.length - 4)
@@ -164,6 +164,13 @@ export default class CreateBarcodeService {
     // Return address including 2 lines of names but without street
     const name1 = `${name.substring(0, name1length)}${lineBreakChar}`.trim()
     const name2 = name.substring(name1length, name.length).trim()
-    return Array.of(name1, name2, recipient.prisonNumber, address.addressName, address.locality, address.postalCode)
+    return Array.of(
+      name1,
+      name2,
+      recipient.prisonNumber,
+      address.addressName,
+      address.locality,
+      address.postalCode
+    ).filter(addressLine => addressLine != null)
   }
 }


### PR DESCRIPTION
Removes any nulls from an address prior to producing the address label:
<img width="464" alt="Screenshot 2022-04-26 at 13 24 04" src="https://user-images.githubusercontent.com/94835226/165299288-53abd79c-1207-4606-a7ca-a662847b28e9.png">

