### PR TITLE
SLM-245 restore cache before running app for int tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,8 @@ jobs:
       - run:
           name: Install missing OS dependency
           command: sudo apt-get install libxss1
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get wiremock
           command: curl -o wiremock.jar https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.27.1/wiremock-standalone-2.27.1.jar
@@ -127,13 +129,11 @@ jobs:
           background: true
       - run:
           name: Run the node app.
-          command: npm run start-feature:dev
+          command: npm run start-feature
           background: true
       - run:
           name: Wait for node app to start
           command: sleep 5
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: integration tests
           command: npm run int-test


### PR DESCRIPTION
This is the fix to a horrible issue we've been suffering where the node app crashed with a segmentation fault when the integration tests started. It appears there was something in the cache that was missing - restoring the cache before running the node app fixed it 🥳 