### PR TITLE
SLM-253 Basic manage supported prison page

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -47,6 +47,7 @@ import OneTimeCodeService from './services/one-time-code-auth/OneTimeCodeService
 import legalSenderJourneyAuthenticationStartPage from './middleware/legalSenderJourneyAuthenticationStartPage'
 import handleSlm404Errors from './middleware/handleSlm404Errors'
 import setupSupportedPrisons from './middleware/prisons/setupSupportedPrisons'
+import SupportedPrisonsService from './services/prison/SupportedPrisonsService'
 
 export default function createApp(
   userService: UserService,
@@ -59,7 +60,8 @@ export default function createApp(
   contactService: ContactService,
   recipientFormService: RecipientFormService,
   zendeskService: ZendeskService,
-  cjsmService: CjsmService
+  cjsmService: CjsmService,
+  supportedPrisonsService: SupportedPrisonsService
 ): express.Application {
   const app = express()
 
@@ -122,7 +124,7 @@ export default function createApp(
   app.use('/', authorisationMiddleware(['ROLE_SLM_SCAN_BARCODE', 'ROLE_SLM_ADMIN']))
 
   app.use('/', setupScanBarcode(scanBarcodeService, prisonRegisterService, appInsightsClient))
-  app.use('/supported-prisons', setupSupportedPrisons())
+  app.use('/supported-prisons', setupSupportedPrisons(supportedPrisonsService))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(process.env.NODE_ENV === 'production'))

--- a/server/filters/prisonsTableRowFilter.test.ts
+++ b/server/filters/prisonsTableRowFilter.test.ts
@@ -1,0 +1,22 @@
+import prisonsTableRowsFilter from './prisonsTableRowsFilter'
+
+describe('prisonsTableRowFilter', () => {
+  it('should render table rows', () => {
+    const prisons = ['ABC', 'CDE']
+
+    const tableRows = prisonsTableRowsFilter(prisons)
+
+    expect(tableRows).toEqual([
+      [
+        { text: 'ABC' },
+        { text: 'ABC' },
+        expect.objectContaining({ html: expect.stringContaining('/supported-prisons/remove/ABC') }),
+      ],
+      [
+        { text: 'CDE' },
+        { text: 'CDE' },
+        expect.objectContaining({ html: expect.stringContaining('/supported-prisons/remove/CDE') }),
+      ],
+    ])
+  })
+})

--- a/server/filters/prisonsTableRowsFilter.ts
+++ b/server/filters/prisonsTableRowsFilter.ts
@@ -1,0 +1,18 @@
+type TableCell = {
+  text?: string
+  html?: string
+}
+
+export default function prisonsTableRowsFilter(prisons: Array<string>): Array<Array<TableCell>> {
+  return prisons.map(prison => {
+    return Array.of(
+      { text: prison },
+      { text: prison },
+      {
+        html: `
+          <a href='/supported-prisons/remove/${prison}' class='govuk-link govuk-link--no-visited-state'>Remove<span class='govuk-visually-hidden'> for ${prison}</span></a>
+          `,
+      }
+    )
+  })
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,6 +15,7 @@ import RecipientFormService from './routes/barcode/recipients/RecipientFormServi
 import ZendeskService from './services/helpdesk/ZendeskService'
 import CjsmService from './services/cjsm/CjsmService'
 import OneTimeCodeService from './services/one-time-code-auth/OneTimeCodeService'
+import SupportedPrisonsService from './services/prison/SupportedPrisonsService'
 
 const app = (appInsightsTelemetryClient?: TelemetryClient): express.Application => {
   const hmppsAuthClient = new HmppsAuthClient(new TokenStore())
@@ -29,6 +30,7 @@ const app = (appInsightsTelemetryClient?: TelemetryClient): express.Application 
   const recipientFormService = new RecipientFormService(prisonRegisterService)
   const zendeskService = new ZendeskService()
   const cjsmService = new CjsmService()
+  const supportedPrisonsService = new SupportedPrisonsService()
 
   return createApp(
     userService,
@@ -41,7 +43,8 @@ const app = (appInsightsTelemetryClient?: TelemetryClient): express.Application 
     contactService,
     recipientFormService,
     zendeskService,
-    cjsmService
+    cjsmService,
+    supportedPrisonsService
   )
 }
 

--- a/server/middleware/prisons/setupSupportedPrisons.ts
+++ b/server/middleware/prisons/setupSupportedPrisons.ts
@@ -1,14 +1,17 @@
 import express, { Router } from 'express'
 import authorisationMiddleware from '../authorisationMiddleware'
 import SupportedPrisonsController from '../../routes/prisons/SupportedPrisonsController'
+import SupportedPrisonsService from '../../services/prison/SupportedPrisonsService'
 
-export default function setupSupportedPrisons(): Router {
+export default function setupSupportedPrisons(supportedPrisonsService: SupportedPrisonsService): Router {
   const router = express.Router()
 
-  const supportedPrisonsController = new SupportedPrisonsController()
+  const supportedPrisonsController = new SupportedPrisonsController(supportedPrisonsService)
 
   router.use('/', authorisationMiddleware(['ROLE_SLM_ADMIN']))
   router.get('/', (req, res) => supportedPrisonsController.getSupportedPrisonsView(req, res))
+  router.post('/add', (req, res) => supportedPrisonsController.addSupportedPrison(req, res))
+  router.get('/remove/:prisonId', (req, res) => supportedPrisonsController.removeSupportedPrison(req, res))
 
   return router
 }

--- a/server/routes/prisons/SupportedPrisonsController.test.ts
+++ b/server/routes/prisons/SupportedPrisonsController.test.ts
@@ -1,24 +1,91 @@
 import { Request, Response } from 'express'
 import SupportedPrisonsController from './SupportedPrisonsController'
+import SupportedPrisonsService from '../../services/prison/SupportedPrisonsService'
 
 const req = {
   flash: jest.fn(),
+  user: { token: 'some-token' },
 } as unknown as Request
 const res = {
   render: jest.fn(),
+  redirect: jest.fn(),
 } as unknown as Response
+const supportedPrisonsService = {
+  getSupportedPrisons: jest.fn(),
+  addSupportedPrison: jest.fn(),
+  removeSupportedPrison: jest.fn(),
+}
 
 describe('SupportedPrisonsController', () => {
-  const supportedPrisonsController = new SupportedPrisonsController()
+  const supportedPrisonsController = new SupportedPrisonsController(
+    supportedPrisonsService as unknown as SupportedPrisonsService
+  )
 
   afterEach(() => {
     jest.resetAllMocks()
   })
 
-  it('should render page', async () => {
-    await supportedPrisonsController.getSupportedPrisonsView(req, res)
+  describe('getSupportedPrisonsView', () => {
+    it('should render page', async () => {
+      supportedPrisonsService.getSupportedPrisons.mockResolvedValue({ supportedPrisons: ['ABC', 'CDE'] })
 
-    expect(res.render).toHaveBeenCalledWith('pages/prisons/supported-prisons', { errors: [] })
-    expect(req.flash).toHaveBeenCalledWith('errors')
+      await supportedPrisonsController.getSupportedPrisonsView(req, res)
+
+      expect(res.render).toHaveBeenCalledWith('pages/prisons/supported-prisons', {
+        prisons: ['ABC', 'CDE'],
+        errors: [],
+      })
+      expect(req.flash).toHaveBeenCalledWith('errors')
+    })
+  })
+
+  describe('addSupportedPrison', () => {
+    it('should add a prison', async () => {
+      req.body = { addPrison: 'ABC' }
+      supportedPrisonsService.addSupportedPrison.mockResolvedValue({})
+
+      await supportedPrisonsController.addSupportedPrison(req, res)
+
+      expect(supportedPrisonsService.addSupportedPrison).toHaveBeenCalledWith('some-token', 'ABC')
+      expect(res.redirect).toHaveBeenCalledWith('/supported-prisons')
+      expect(req.flash).not.toHaveBeenCalled()
+    })
+
+    it('should show errors if add prison fails', async () => {
+      req.body = { addPrison: 'ABC' }
+      supportedPrisonsService.addSupportedPrison.mockRejectedValue({
+        status: 404,
+        data: { errorCode: { code: 'NOT_FOUND', userMessage: 'Not Found' } },
+      })
+
+      await supportedPrisonsController.addSupportedPrison(req, res)
+
+      expect(req.flash).toHaveBeenCalledWith('errors', [{ href: '#addPrison', text: 'Not Found' }])
+    })
+  })
+
+  describe('removeSupportedPrison', () => {
+    it('should remove a prison', async () => {
+      req.params = { prisonId: 'ABC' }
+      supportedPrisonsService.removeSupportedPrison.mockResolvedValue({})
+
+      await supportedPrisonsController.removeSupportedPrison(req, res)
+
+      expect(supportedPrisonsService.removeSupportedPrison).toHaveBeenCalledWith('some-token', 'ABC')
+      expect(res.redirect).toHaveBeenCalledWith('/supported-prisons')
+      expect(req.flash).not.toHaveBeenCalled()
+    })
+
+    it('should show errors if remove prison fails', async () => {
+      req.params = { prisonId: 'ABC' }
+      supportedPrisonsService.removeSupportedPrison.mockRejectedValue({
+        status: 404,
+        data: { errorCode: { code: 'NOT_FOUND', userMessage: 'Not Found' } },
+      })
+
+      await supportedPrisonsController.removeSupportedPrison(req, res)
+
+      expect(req.flash).toHaveBeenCalledWith('errors', [{ text: 'Not Found' }])
+    })
   })
 })

--- a/server/routes/prisons/SupportedPrisonsController.ts
+++ b/server/routes/prisons/SupportedPrisonsController.ts
@@ -1,10 +1,34 @@
 import { Request, Response } from 'express'
 import SupportedPrisonsView from './SupportedPrisonsView'
+import SupportedPrisonsService from '../../services/prison/SupportedPrisonsService'
 
 export default class SupportedPrisonsController {
+  constructor(private readonly supportedPrisonsService: SupportedPrisonsService) {}
+
   async getSupportedPrisonsView(req: Request, res: Response): Promise<void> {
-    const view = new SupportedPrisonsView(req.flash('errors'))
+    const response = await this.supportedPrisonsService.getSupportedPrisons(req.user.token)
+    const view = new SupportedPrisonsView(response.supportedPrisons, req.flash('errors'))
 
     return res.render('pages/prisons/supported-prisons', { ...view.renderArgs })
+  }
+
+  async addSupportedPrison(req: Request, res: Response): Promise<void> {
+    try {
+      await this.supportedPrisonsService.addSupportedPrison(req.user.token, req.body.addPrison)
+    } catch (error) {
+      req.flash('errors', [{ href: '#addPrison', text: error.data.errorCode.userMessage }])
+    }
+
+    return res.redirect('/supported-prisons')
+  }
+
+  async removeSupportedPrison(req: Request, res: Response): Promise<void> {
+    try {
+      await this.supportedPrisonsService.removeSupportedPrison(req.user.token, req.params.prisonId)
+    } catch (error) {
+      req.flash('errors', [{ text: error.data.errorCode.userMessage }])
+    }
+
+    return res.redirect('/supported-prisons')
   }
 }

--- a/server/routes/prisons/SupportedPrisonsView.ts
+++ b/server/routes/prisons/SupportedPrisonsView.ts
@@ -1,7 +1,7 @@
 export default class SupportedPrisonsView {
-  constructor(private readonly errors?: Array<Record<string, string>>) {}
+  constructor(private readonly prisons: string[], private readonly errors?: Array<Record<string, string>>) {}
 
-  get renderArgs(): { errors: Array<Record<string, string>> } {
-    return { errors: this.errors || [] }
+  get renderArgs(): { prisons: Array<string>; errors: Array<Record<string, string>> } {
+    return { prisons: this.prisons, errors: this.errors || [] }
   }
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -12,6 +12,7 @@ import renderChooseContactRadiosFilter from '../filters/renderChooseContactRadio
 import config from '../config'
 import pageTitleInErrorFilter from '../filters/pageTitleInErrorFilter'
 import formatDateFilter from '../filters/formatDateFilter'
+import prisonsTableRowsFilter from '../filters/prisonsTableRowsFilter'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -83,6 +84,7 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('renderChooseBarcodeOptionRadiosFilter', renderChooseBarcodeOptionRadiosFilter)
   njkEnv.addFilter('renderChooseContactRadiosFilter', renderChooseContactRadiosFilter)
   njkEnv.addFilter('pageTitleInErrorFilter', pageTitleInErrorFilter)
+  njkEnv.addFilter('prisonTableRowsFilter', prisonsTableRowsFilter)
 
   njkEnv.addGlobal('contactHelpdeskBannerExcludedOnPages', [
     'auth-error',

--- a/server/views/pages/prisons/supported-prisons.njk
+++ b/server/views/pages/prisons/supported-prisons.njk
@@ -19,7 +19,7 @@
     {% endif %}
 
     <div class="govuk-grid-row" id="scan-barcode-form">
-      <div class="govuk-grid-column-full">
+      <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">Manage supported prisons</h1>
 
         <p>This is still a work in progress and does not actually change the legal sender prison lists yet.</p>
@@ -55,7 +55,6 @@
               text: "Example, LEI"
             },
             attributes: {
-              autofocus: '',
               autocomplete: 'off'
             },
             id: "addPrison",

--- a/server/views/pages/prisons/supported-prisons.njk
+++ b/server/views/pages/prisons/supported-prisons.njk
@@ -1,9 +1,11 @@
 {% extends "layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% set pageTitle = applicationName + " - Manage supported prisons" %}
-{% set pageId = 'supported-prisons' %}
+{% set pageId = 'manage-supported-prisons' %}
 
 {% block content %}
 
@@ -17,10 +19,57 @@
     {% endif %}
 
     <div class="govuk-grid-row" id="scan-barcode-form">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Manage supported prisons - coming soon</h1>
+      <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-xl">Manage supported prisons</h1>
 
-        <p>Please select which prisons legal senders can send Rule39 mail to.</p>
+        <p>This is still a work in progress and does not actually change the legal sender prison lists yet.</p>
+
+        {% if prisons.length > 0 %}
+          {{ govukTable({
+            firstCellIsHeader: true,
+            head: [
+              { text: 'Prison Code' },
+              { text: 'Prison name' },
+              { text: 'Remove', classes: 'govuk-!-width-one-quarter' }
+            ],
+            rows: prisons | prisonTableRowsFilter,
+            attributes: { id: 'manage-supported-prisons-table' }
+          }) }}
+
+        {% else %}
+
+          <p class="govuk-!-margin-bottom-6" data-qa="no-prisons">
+            There are no supported prisons.
+          </p>
+
+        {% endif %}
+
+        <form action="/supported-prisons/add" method="post" data-qa="add-prison-form">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+          {{ govukInput({
+            label: {
+              text: "Prison code",
+              isPageHeading: false
+            },
+            hint: {
+              text: "Example, LEI"
+            },
+            attributes: {
+              autofocus: '',
+              autocomplete: 'off'
+            },
+            id: "addPrison",
+            name: "addPrison",
+            value: addPrison,
+            classes: 'govuk-input--width-10',
+            errorMessage: errors | findError('prisonId')
+          }) }}
+          {{ govukButton({
+            text: 'Add',
+            preventDoubleClick: true,
+            attributes: { 'data-qa': 'add-another-prison' }
+          }) }}
+        </form>
 
       </div>
     </div>

--- a/server/views/pages/prisons/supported-prisons.test.ts
+++ b/server/views/pages/prisons/supported-prisons.test.ts
@@ -20,7 +20,7 @@ describe('Manage supported prisons view', () => {
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('#supported-prisons').length).toStrictEqual(1)
+    expect($('#manage-supported-prisons').length).toStrictEqual(1)
   })
 
   it('should show errors', () => {
@@ -28,7 +28,35 @@ describe('Manage supported prisons view', () => {
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('#supported-prisons').length).toStrictEqual(1)
     expect($('div.govuk-error-summary').text()).toContain('some-error')
+  })
+
+  it('should not display prison table if no prisons', () => {
+    viewContext = { errors: [] }
+
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('p[data-qa=no-prisons]').length).toStrictEqual(1)
+    expect($('#manage-supported-prisons-table').length).toStrictEqual(0)
+  })
+
+  it('should display prison table', () => {
+    viewContext = { prisons: ['ABC', 'CDE'], errors: [] }
+
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('p[data-qa=no-prisons]').length).toStrictEqual(0)
+    expect($('#manage-supported-prisons-table').length).toStrictEqual(1)
+    expect($('#manage-supported-prisons-table').find('tr').length).toStrictEqual(3)
+  })
+
+  it('should display add prison form', () => {
+    viewContext = { errors: [] }
+
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('form[data-qa=add-prison-form]').length).toStrictEqual(1)
+    expect($('form[data-qa=add-prison-form]').find('input#addPrison').length).toStrictEqual(1)
+    expect($('form[data-qa=add-prison-form]').find('button[data-qa=add-another-prison]').length).toStrictEqual(1)
   })
 })


### PR DESCRIPTION
Display supported prisons and allow add/remove.

**TODO**
* make add prison input a select containing prisons not yet added
* show prison name
* tidy up error handling
* replace existing supported prison config with prisons selected
* add some integration tests

![image](https://user-images.githubusercontent.com/58170926/170303359-f32a7421-386b-45dc-b024-09c7b4e5b0a5.png)
