### PR TITLE
SLM-253 Make PrisonService the single access point to services/prisons

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -40,13 +40,11 @@ const app = (appInsightsTelemetryClient?: TelemetryClient): express.Application 
     oneTimeCodeService,
     scanBarcodeService,
     createBarcodeService,
-    prisonRegisterService,
     appInsightsService,
     contactService,
     recipientFormService,
     zendeskService,
     cjsmService,
-    supportedPrisonsService,
     prisonService
   )
 }

--- a/server/middleware/barcode/setupBarcode.ts
+++ b/server/middleware/barcode/setupBarcode.ts
@@ -1,7 +1,6 @@
 import express, { Router } from 'express'
 import FindRecipientController from '../../routes/barcode/recipients/FindRecipientController'
 import CreateBarcodeService from '../../services/barcode/CreateBarcodeService'
-import PrisonRegisterService from '../../services/prison/PrisonRegisterService'
 import ReviewRecipientsController from '../../routes/barcode/review/ReviewRecipientsController'
 import CreateContactByPrisonNumberController from '../../routes/barcode/contacts/CreateContactByPrisonNumberController'
 import GenerateBarcodeImageController from '../../routes/barcode/image/GenerateBarcodeImageController'
@@ -12,10 +11,11 @@ import ContactService from '../../services/contacts/ContactService'
 import RecipientFormService from '../../routes/barcode/recipients/RecipientFormService'
 import ChooseContactController from '../../routes/barcode/contacts/ChooseContactController'
 import EditContactController from '../../routes/barcode/contacts/EditContactController'
+import PrisonService from '../../services/prison/PrisonService'
 
 export default function setUpCreateBarcode(
   createBarcodeService: CreateBarcodeService,
-  prisonRegisterService: PrisonRegisterService,
+  prisonService: PrisonService,
   contactService: ContactService,
   recipientFormService: RecipientFormService
 ): Router {
@@ -23,20 +23,20 @@ export default function setUpCreateBarcode(
   const findRecipientController = new FindRecipientController(recipientFormService, contactService)
   const chooseContactController = new ChooseContactController(recipientFormService)
   const createContactByPrisonNumberController = new CreateContactByPrisonNumberController(
-    prisonRegisterService,
+    prisonService,
     contactService,
     recipientFormService
   )
   const createContactByPrisonerNameController = new CreateContactByPrisonerNameController(
-    prisonRegisterService,
+    prisonService,
     contactService,
     recipientFormService
   )
-  const reviewRecipientsController = new ReviewRecipientsController(prisonRegisterService)
+  const reviewRecipientsController = new ReviewRecipientsController(prisonService)
   const chooseBarcodeOptionController = new ChooseBarcodeOptionController()
   const generateImageController = new GenerateBarcodeImageController(createBarcodeService)
   const pdfController = new PdfController(createBarcodeService)
-  const editContactController = new EditContactController(prisonRegisterService, contactService, recipientFormService)
+  const editContactController = new EditContactController(prisonService, contactService, recipientFormService)
 
   router.get('/find-recipient', (req, res) => res.redirect('/barcode/find-recipient/by-prison-number'))
   router.get('/find-recipient/by-prison-number', (req, res) =>

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -2,12 +2,9 @@ import { RequestHandler } from 'express'
 import logger from '../../logger'
 import UserService from '../services/userService'
 import config from '../config'
-import PrisonRegisterService from '../services/prison/PrisonRegisterService'
+import PrisonService from '../services/prison/PrisonService'
 
-export default function populateCurrentUser(
-  userService: UserService,
-  prisonRegisterService: PrisonRegisterService
-): RequestHandler {
+export default function populateCurrentUser(userService: UserService, prisonService: PrisonService): RequestHandler {
   return async (req, res, next) => {
     try {
       if (config.smoketest.msjSecret && req.session?.msjSmokeTestUser) {
@@ -17,7 +14,7 @@ export default function populateCurrentUser(
         const user = res.locals.user && (await userService.getUser(res.locals.user.token))
         if (user) {
           res.locals.user = { ...user, ...res.locals.user }
-          res.locals.user.prisonName = await prisonRegisterService.getPrisonNameOrId(res.locals.user.activeCaseLoadId)
+          res.locals.user.prisonName = await prisonService.getPrisonNameOrId(res.locals.user.activeCaseLoadId)
         } else {
           logger.info('No user available')
         }

--- a/server/middleware/prisons/setupSupportedPrisons.ts
+++ b/server/middleware/prisons/setupSupportedPrisons.ts
@@ -1,16 +1,12 @@
 import express, { Router } from 'express'
 import authorisationMiddleware from '../authorisationMiddleware'
 import SupportedPrisonsController from '../../routes/prisons/SupportedPrisonsController'
-import SupportedPrisonsService from '../../services/prison/SupportedPrisonsService'
 import PrisonService from '../../services/prison/PrisonService'
 
-export default function setupSupportedPrisons(
-  supportedPrisonsService: SupportedPrisonsService,
-  prisonService: PrisonService
-): Router {
+export default function setupSupportedPrisons(prisonService: PrisonService): Router {
   const router = express.Router()
 
-  const supportedPrisonsController = new SupportedPrisonsController(supportedPrisonsService, prisonService)
+  const supportedPrisonsController = new SupportedPrisonsController(prisonService)
 
   router.use('/', authorisationMiddleware(['ROLE_SLM_ADMIN']))
   router.get('/', (req, res) => supportedPrisonsController.getSupportedPrisonsView(req, res))

--- a/server/middleware/scan/setupScanBarcode.ts
+++ b/server/middleware/scan/setupScanBarcode.ts
@@ -3,19 +3,19 @@ import authorisationMiddleware from '../authorisationMiddleware'
 import ScanBarcodeController from '../../routes/scan/ScanBarcodeController'
 import ScanBarcodeService from '../../services/scan/ScanBarcodeService'
 import AppInsightsService from '../../services/AppInsightsService'
-import PrisonRegisterService from '../../services/prison/PrisonRegisterService'
 import VerifyBarcodeErrorResponseMapper from '../../routes/scan/VerifyBarcodeErrorResponseMapper'
+import PrisonService from '../../services/prison/PrisonService'
 
 export default function setupScanBarcode(
   scanBarcodeService: ScanBarcodeService,
-  prisonRegisterService: PrisonRegisterService,
+  prisonService: PrisonService,
   appInsightsClient: AppInsightsService
 ): Router {
   const router = express.Router()
 
   const scanBarcodeController = new ScanBarcodeController(
     scanBarcodeService,
-    new VerifyBarcodeErrorResponseMapper(prisonRegisterService),
+    new VerifyBarcodeErrorResponseMapper(prisonService),
     appInsightsClient
   )
 

--- a/server/middleware/start/setupLegalSenderStartPage.ts
+++ b/server/middleware/start/setupLegalSenderStartPage.ts
@@ -1,10 +1,10 @@
 import express, { Router } from 'express'
 import StartPageController from '../../routes/start/StartPageController'
-import PrisonRegisterService from '../../services/prison/PrisonRegisterService'
+import PrisonService from '../../services/prison/PrisonService'
 
-export default function setupLegalSenderStartPage(prisonRegisterService: PrisonRegisterService): Router {
+export default function setupLegalSenderStartPage(prisonService: PrisonService): Router {
   const router = express.Router()
-  const startPageController = new StartPageController(prisonRegisterService)
+  const startPageController = new StartPageController(prisonService)
 
   router.get('/', (req, res) => startPageController.getStartPageView(req, res))
 

--- a/server/routes/barcode/contacts/CreateContactByPrisonNumberController.ts
+++ b/server/routes/barcode/contacts/CreateContactByPrisonNumberController.ts
@@ -1,16 +1,16 @@
 import { Request, Response } from 'express'
 import type { Prison } from 'prisonTypes'
 import validateNewContact from './newContactByPrisonNumberValidator'
-import PrisonRegisterService from '../../../services/prison/PrisonRegisterService'
 import CreateContactByPrisonNumberView from './CreateContactByPrisonNumberView'
 import filterSupportedPrisons from './filterSupportedPrisons'
 import ContactService from '../../../services/contacts/ContactService'
 import logger from '../../../../logger'
 import RecipientFormService from '../recipients/RecipientFormService'
+import PrisonService from '../../../services/prison/PrisonService'
 
 export default class CreateContactByPrisonNumberController {
   constructor(
-    private readonly prisonRegisterService: PrisonRegisterService,
+    private readonly prisonService: PrisonService,
     private readonly contactService: ContactService,
     private readonly recipientFormService: RecipientFormService
   ) {}
@@ -23,7 +23,7 @@ export default class CreateContactByPrisonNumberController {
 
     let activePrisons: Array<Prison>
     try {
-      activePrisons = await this.prisonRegisterService.getActivePrisonsFromPrisonRegister()
+      activePrisons = await this.prisonService.getPrisons()
     } catch (error) {
       req.flash('errors', [{ text: 'There was an error retrieving the list of prisons' }])
       activePrisons = []

--- a/server/routes/barcode/contacts/CreateContactByPrisonerNameController.ts
+++ b/server/routes/barcode/contacts/CreateContactByPrisonerNameController.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express'
 import type { Prison } from 'prisonTypes'
-import PrisonRegisterService from '../../../services/prison/PrisonRegisterService'
 import CreateContactByPrisonerNameView from './CreateContactByPrisonerNameView'
 import validateNewContact from './newContactByPrisonerNameValidator'
 import filterSupportedPrisons from './filterSupportedPrisons'
@@ -8,10 +7,11 @@ import ContactService from '../../../services/contacts/ContactService'
 import logger from '../../../../logger'
 import RecipientFormService from '../recipients/RecipientFormService'
 import parseDob from './parseDob'
+import PrisonService from '../../../services/prison/PrisonService'
 
 export default class CreateContactByPrisonerNameController {
   constructor(
-    private readonly prisonRegisterService: PrisonRegisterService,
+    private readonly prisonService: PrisonService,
     private readonly contactService: ContactService,
     private readonly recipientFormService: RecipientFormService
   ) {}
@@ -24,7 +24,7 @@ export default class CreateContactByPrisonerNameController {
 
     let activePrisons: Array<Prison>
     try {
-      activePrisons = await this.prisonRegisterService.getActivePrisonsFromPrisonRegister()
+      activePrisons = await this.prisonService.getPrisons()
     } catch (error) {
       req.flash('errors', [{ text: 'There was an error retrieving the list of prisons' }])
       activePrisons = []

--- a/server/routes/barcode/contacts/EditContactController.ts
+++ b/server/routes/barcode/contacts/EditContactController.ts
@@ -3,7 +3,6 @@ import type { Prison } from 'prisonTypes'
 import moment from 'moment'
 import type { Contact } from 'sendLegalMailApiClient'
 import type { EditContactForm } from 'forms'
-import PrisonRegisterService from '../../../services/prison/PrisonRegisterService'
 import EditContactView from './EditContactView'
 import logger from '../../../../logger'
 import ContactService from '../../../services/contacts/ContactService'
@@ -11,10 +10,11 @@ import filterSupportedPrisons from './filterSupportedPrisons'
 import parseDob from './parseDob'
 import validateContact from './updateContactValidator'
 import RecipientFormService from '../recipients/RecipientFormService'
+import PrisonService from '../../../services/prison/PrisonService'
 
 export default class EditContactController {
   constructor(
-    private readonly prisonRegisterService: PrisonRegisterService,
+    private readonly prisonService: PrisonService,
     private readonly contactService: ContactService,
     private readonly recipientService: RecipientFormService
   ) {}
@@ -29,7 +29,7 @@ export default class EditContactController {
 
     let activePrisons: Array<Prison>
     try {
-      activePrisons = await this.prisonRegisterService.getActivePrisonsFromPrisonRegister()
+      activePrisons = await this.prisonService.getPrisons()
     } catch (error) {
       logger.error(`Unable to load prisons due to error`, error)
       req.flash('errors', [{ text: 'There was an error retrieving the list of prisons' }])

--- a/server/routes/barcode/review/ReviewRecipientsController.ts
+++ b/server/routes/barcode/review/ReviewRecipientsController.ts
@@ -1,9 +1,9 @@
 import { Request, Response } from 'express'
 import ReviewRecipientsView from './ReviewRecipientsView'
-import PrisonRegisterService from '../../../services/prison/PrisonRegisterService'
+import PrisonService from '../../../services/prison/PrisonService'
 
 export default class ReviewRecipientsController {
-  constructor(private readonly prisonRegisterService: PrisonRegisterService) {}
+  constructor(private readonly prisonService: PrisonService) {}
 
   async getReviewRecipientsView(req: Request, res: Response): Promise<void> {
     if (!req.session.recipients) {
@@ -74,7 +74,7 @@ export default class ReviewRecipientsController {
 
           const newRecipient = {
             ...recipient,
-            prison: await this.prisonRegisterService.getPrison(recipient.prisonAddress.agencyCode),
+            prison: await this.prisonService.getPrison(recipient.prisonAddress.agencyCode),
           }
           delete newRecipient.prisonAddress
           return newRecipient

--- a/server/routes/prisons/SupportedPrisonsController.test.ts
+++ b/server/routes/prisons/SupportedPrisonsController.test.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express'
 import SupportedPrisonsController from './SupportedPrisonsController'
-import SupportedPrisonsService from '../../services/prison/SupportedPrisonsService'
 import validatePrisonId from '../barcode/validators/prisonIdValidator'
 import PrisonService from '../../services/prison/PrisonService'
 
@@ -16,22 +15,16 @@ const res = {
   render: jest.fn(),
   redirect: jest.fn(),
 }
-const supportedPrisonsService = {
-  getSupportedPrisons: jest.fn(),
-  addSupportedPrison: jest.fn(),
-  removeSupportedPrison: jest.fn(),
-}
 const prisonService = {
   getPrisonsBySupported: jest.fn(),
+  addSupportedPrison: jest.fn(),
+  removeSupportedPrison: jest.fn(),
 }
 
 describe('SupportedPrisonsController', () => {
   let mockValidatePrisonId: jest.MockedFunction<typeof validatePrisonId>
 
-  const supportedPrisonsController = new SupportedPrisonsController(
-    supportedPrisonsService as unknown as SupportedPrisonsService,
-    prisonService as unknown as PrisonService
-  )
+  const supportedPrisonsController = new SupportedPrisonsController(prisonService as unknown as PrisonService)
 
   beforeEach(() => {
     mockValidatePrisonId = validatePrisonId as jest.MockedFunction<typeof validatePrisonId>
@@ -75,11 +68,11 @@ describe('SupportedPrisonsController', () => {
     it('should add a prison', async () => {
       req.body = { prisonId: 'ABC' }
       mockValidatePrisonId.mockReturnValue([])
-      supportedPrisonsService.addSupportedPrison.mockResolvedValue({})
+      prisonService.addSupportedPrison.mockResolvedValue({})
 
       await supportedPrisonsController.addSupportedPrison(req as unknown as Request, res as unknown as Response)
 
-      expect(supportedPrisonsService.addSupportedPrison).toHaveBeenCalledWith('some-token', 'ABC')
+      expect(prisonService.addSupportedPrison).toHaveBeenCalledWith('some-token', 'ABC')
       expect(res.redirect).toHaveBeenCalledWith('/supported-prisons')
       expect(req.flash).not.toHaveBeenCalled()
     })
@@ -96,7 +89,7 @@ describe('SupportedPrisonsController', () => {
     it('should show errors if add prison fails', async () => {
       req.body = { prisonId: 'ABC' }
       mockValidatePrisonId.mockReturnValue([])
-      supportedPrisonsService.addSupportedPrison.mockRejectedValue({
+      prisonService.addSupportedPrison.mockRejectedValue({
         status: 404,
         data: { errorCode: { code: 'NOT_FOUND', userMessage: 'Not Found' } },
       })
@@ -110,18 +103,18 @@ describe('SupportedPrisonsController', () => {
   describe('removeSupportedPrison', () => {
     it('should remove a prison', async () => {
       req.params = { prisonId: 'ABC' }
-      supportedPrisonsService.removeSupportedPrison.mockResolvedValue({})
+      prisonService.removeSupportedPrison.mockResolvedValue({})
 
       await supportedPrisonsController.removeSupportedPrison(req as unknown as Request, res as unknown as Response)
 
-      expect(supportedPrisonsService.removeSupportedPrison).toHaveBeenCalledWith('some-token', 'ABC')
+      expect(prisonService.removeSupportedPrison).toHaveBeenCalledWith('some-token', 'ABC')
       expect(res.redirect).toHaveBeenCalledWith('/supported-prisons')
       expect(req.flash).not.toHaveBeenCalled()
     })
 
     it('should show errors if remove prison fails', async () => {
       req.params = { prisonId: 'ABC' }
-      supportedPrisonsService.removeSupportedPrison.mockRejectedValue({
+      prisonService.removeSupportedPrison.mockRejectedValue({
         status: 404,
         data: { errorCode: { code: 'NOT_FOUND', userMessage: 'Not Found' } },
       })

--- a/server/routes/prisons/SupportedPrisonsController.ts
+++ b/server/routes/prisons/SupportedPrisonsController.ts
@@ -2,15 +2,11 @@ import { Request, Response } from 'express'
 import SupportedPrisonsView from './SupportedPrisonsView'
 import validatePrisonId from '../barcode/validators/prisonIdValidator'
 import formatErrors from '../errorFormatter'
-import PrisonService from '../../services/prison/PrisonService'
-import SupportedPrisonsService from '../../services/prison/SupportedPrisonsService'
 import logger from '../../../logger'
+import PrisonService from '../../services/prison/PrisonService'
 
 export default class SupportedPrisonsController {
-  constructor(
-    private readonly supportedPrisonsService: SupportedPrisonsService,
-    private readonly prisonService: PrisonService
-  ) {}
+  constructor(private readonly prisonService: PrisonService) {}
 
   async getSupportedPrisonsView(req: Request, res: Response): Promise<void> {
     try {
@@ -34,7 +30,7 @@ export default class SupportedPrisonsController {
     }
 
     try {
-      await this.supportedPrisonsService.addSupportedPrison(req.user.token, req.body.prisonId)
+      await this.prisonService.addSupportedPrison(req.user.token, req.body.prisonId)
     } catch (error) {
       req.flash('errors', [{ href: '#prisonId', text: error.data.errorCode.userMessage }])
     }
@@ -44,7 +40,7 @@ export default class SupportedPrisonsController {
 
   async removeSupportedPrison(req: Request, res: Response): Promise<void> {
     try {
-      await this.supportedPrisonsService.removeSupportedPrison(req.user.token, req.params.prisonId)
+      await this.prisonService.removeSupportedPrison(req.user.token, req.params.prisonId)
     } catch (error) {
       req.flash('errors', [{ text: error.data.errorCode.userMessage }])
     }

--- a/server/routes/scan/VerifyBarcodeErrorResponseMapper.test.ts
+++ b/server/routes/scan/VerifyBarcodeErrorResponseMapper.test.ts
@@ -1,18 +1,18 @@
 import type { DuplicateErrorCode, RandomCheckErrorCode } from 'sendLegalMailApiClient'
-import PrisonRegisterService from '../../services/prison/PrisonRegisterService'
 import VerifyBarcodeErrorResponseMapper from './VerifyBarcodeErrorResponseMapper'
+import PrisonService from '../../services/prison/PrisonService'
 
 describe('VerifyBarcodeErrorResponseMapper', () => {
-  const prisonRegisterService = {
+  const prisonService = {
     getPrisonNameOrId: jest.fn(),
   }
 
   const verifyBarcodeErrorResponseMapper = new VerifyBarcodeErrorResponseMapper(
-    prisonRegisterService as unknown as PrisonRegisterService
+    prisonService as unknown as PrisonService
   )
 
   afterEach(() => {
-    prisonRegisterService.getPrisonNameOrId.mockReset()
+    prisonService.getPrisonNameOrId.mockReset()
   })
 
   describe('mapErrorResponse', () => {
@@ -32,7 +32,7 @@ describe('VerifyBarcodeErrorResponseMapper', () => {
           errorCode: apiErrorCode,
         },
       }
-      prisonRegisterService.getPrisonNameOrId.mockReturnValue('HMP Altcourse')
+      prisonService.getPrisonNameOrId.mockReturnValue('HMP Altcourse')
 
       const errorCode = await verifyBarcodeErrorResponseMapper.mapErrorResponse(apiErrorResponse)
 
@@ -44,7 +44,7 @@ describe('VerifyBarcodeErrorResponseMapper', () => {
         recipientPrisonNumber: 'A1234BC',
         recipientDob: '1990-01-31',
       })
-      expect(prisonRegisterService.getPrisonNameOrId).toHaveBeenCalledWith('ACI')
+      expect(prisonService.getPrisonNameOrId).toHaveBeenCalledWith('ACI')
     })
 
     it('should map Expired', async () => {

--- a/server/routes/scan/VerifyBarcodeErrorResponseMapper.ts
+++ b/server/routes/scan/VerifyBarcodeErrorResponseMapper.ts
@@ -1,14 +1,14 @@
 import type { DuplicateErrorCode, ErrorCode, ErrorResponse } from 'sendLegalMailApiClient'
-import PrisonRegisterService from '../../services/prison/PrisonRegisterService'
+import PrisonService from '../../services/prison/PrisonService'
 
 export default class VerifyBarcodeErrorResponseMapper {
-  constructor(private readonly prisonRegisterService: PrisonRegisterService) {}
+  constructor(private readonly prisonService: PrisonService) {}
 
   mapErrorResponse = async (apiErrorResponse: { data?: ErrorResponse; status?: number }): ErrorCode => {
     const errorType = apiErrorResponse.data?.errorCode?.code
     if (errorType === 'DUPLICATE') {
       const { scannedLocation } = apiErrorResponse.data.errorCode as DuplicateErrorCode
-      const prisonName = await this.prisonRegisterService.getPrisonNameOrId(scannedLocation)
+      const prisonName = await this.prisonService.getPrisonNameOrId(scannedLocation)
       return {
         ...apiErrorResponse.data.errorCode,
         scannedLocation: prisonName,

--- a/server/routes/standardRouter.ts
+++ b/server/routes/standardRouter.ts
@@ -5,17 +5,17 @@ import populateCurrentUser from '../middleware/populateCurrentUser'
 import type UserService from '../services/userService'
 import populateCurrentUserRoles from '../middleware/populateCurrentUserRoles'
 import SmokeTestStore from '../data/cache/SmokeTestStore'
-import PrisonRegisterService from '../services/prison/PrisonRegisterService'
+import PrisonService from '../services/prison/PrisonService'
 
 export default function standardRouter(
   userService: UserService,
   smokeTestStore: SmokeTestStore,
-  prisonRegisterService: PrisonRegisterService
+  prisonService: PrisonService
 ): Router {
   const router = Router({ mergeParams: true })
 
   router.use(auth.authenticationMiddleware(tokenVerifier, smokeTestStore))
-  router.use(populateCurrentUser(userService, prisonRegisterService))
+  router.use(populateCurrentUser(userService, prisonService))
   router.use(populateCurrentUserRoles())
 
   return router

--- a/server/routes/start/StartPageController.test.ts
+++ b/server/routes/start/StartPageController.test.ts
@@ -1,22 +1,22 @@
 import { Request, Response } from 'express'
 import config from '../../config'
 import StartPageController from './StartPageController'
-import PrisonRegisterService from '../../services/prison/PrisonRegisterService'
+import PrisonService from '../../services/prison/PrisonService'
 
 const res = {
   render: jest.fn(),
   redirect: jest.fn(),
 }
 
-const prisonRegisterService = {
-  getActivePrisonsFromPrisonRegister: jest.fn(),
+const prisonService = {
+  getPrisons: jest.fn(),
 }
 
 describe('StartPageController', () => {
-  const startPageController = new StartPageController(prisonRegisterService as unknown as PrisonRegisterService)
+  const startPageController = new StartPageController(prisonService as unknown as PrisonService)
 
   config.supportedPrisons = ''
-  prisonRegisterService.getActivePrisonsFromPrisonRegister.mockResolvedValue([
+  prisonService.getPrisons.mockResolvedValue([
     { id: 'KTI', name: 'Kennet (HMP)', addressName: 'HMP Kennet' },
     { id: 'ACI', name: 'Altcourse (HMP)', addressName: 'HMP Altcourse' },
     { id: 'ASI', name: 'Ashfield (HMP & YOI)', addressName: 'HMP & YOI Ashfield' },
@@ -25,7 +25,7 @@ describe('StartPageController', () => {
   it('should display all prison address names in alphabetical order by name (not type)', async () => {
     await startPageController.getStartPageView({} as unknown as Request, res as unknown as Response)
 
-    expect(prisonRegisterService.getActivePrisonsFromPrisonRegister).toHaveBeenCalled()
+    expect(prisonService.getPrisons).toHaveBeenCalled()
     expect(res.render).toHaveBeenCalledWith('pages/start/legal-sender-start-page', {
       prisonNames: ['HMP Altcourse', 'HMP & YOI Ashfield', 'HMP Kennet'],
     })

--- a/server/routes/start/StartPageController.ts
+++ b/server/routes/start/StartPageController.ts
@@ -1,14 +1,12 @@
 import { Request, Response } from 'express'
-import PrisonRegisterService from '../../services/prison/PrisonRegisterService'
 import filterSupportedPrisons from '../barcode/contacts/filterSupportedPrisons'
+import PrisonService from '../../services/prison/PrisonService'
 
 export default class StartPageController {
-  constructor(private readonly prisonRegisterService: PrisonRegisterService) {}
+  constructor(private readonly prisonService: PrisonService) {}
 
   async getStartPageView(req: Request, res: Response): Promise<void> {
-    const supportedPrisons = filterSupportedPrisons(
-      await this.prisonRegisterService.getActivePrisonsFromPrisonRegister()
-    )
+    const supportedPrisons = filterSupportedPrisons(await this.prisonService.getPrisons())
     const supportedPrisonNames = supportedPrisons
       .sort((a, b) => a.name.localeCompare(b.name))
       .map(prison => prison.addressName)

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -11,8 +11,10 @@ import standardRouter from '../standardRouter'
 import UserService from '../../services/userService'
 import * as auth from '../../authentication/auth'
 import SmokeTestStore from '../../data/cache/SmokeTestStore'
-import PrisonRegisterService from '../../services/prison/PrisonRegisterService'
 import PrisonRegisterStore from '../../data/cache/PrisonRegisterStore'
+import PrisonService from '../../services/prison/PrisonService'
+import PrisonRegisterService from '../../services/prison/PrisonRegisterService'
+import SupportedPrisonsService from '../../services/prison/SupportedPrisonsService'
 
 const user = {
   name: 'john smith',
@@ -57,6 +59,10 @@ class MockPrisonerRegister extends PrisonRegisterService {
 
 class MockPrisonRegisterStore extends PrisonRegisterStore {}
 
+class MockSupportedPrisonsService extends SupportedPrisonsService {}
+
+class MockPrisonService extends PrisonService {}
+
 function appSetup(route: Router, production: boolean): Express {
   const app = express()
 
@@ -92,7 +98,10 @@ export default function appWithAllRoutes({ production = false }: { production?: 
       standardRouter(
         new MockUserService(),
         new MockSmokeTestStore(),
-        new MockPrisonerRegister(new MockPrisonRegisterStore())
+        new MockPrisonService(
+          new MockPrisonerRegister(new MockPrisonRegisterStore()),
+          new MockSupportedPrisonsService()
+        )
       )
     ),
     production

--- a/server/services/prison/PrisonService.ts
+++ b/server/services/prison/PrisonService.ts
@@ -17,6 +17,14 @@ export default class PrisonService {
     return this.prisonRegisterService.getActivePrisonsFromPrisonRegister()
   }
 
+  async getPrison(prisonId: string): Promise<Prison> {
+    return this.prisonRegisterService.getPrison(prisonId)
+  }
+
+  async getPrisonNameOrId(prisonId: string): Promise<string> {
+    return this.prisonRegisterService.getPrisonNameOrId(prisonId)
+  }
+
   async getSupportedPrisons(authToken: string): Promise<Array<Prison>> {
     const [prisons, supportedPrisonCodes] = await Promise.all([
       this.prisonRegisterService.getActivePrisonsFromPrisonRegister(),
@@ -34,6 +42,14 @@ export default class PrisonService {
       supportedPrisons: this.supportedPrisons(prisons, supportedPrisonCodes.supportedPrisons),
       unsupportedPrisons: this.unsupportedPrisons(prisons, supportedPrisonCodes.supportedPrisons),
     }
+  }
+
+  async addSupportedPrison(userToken: string, prisonId: string): Promise<unknown> {
+    return this.supportedPrisonsService.addSupportedPrison(userToken, prisonId)
+  }
+
+  async removeSupportedPrison(userToken: string, prisonId: string): Promise<unknown> {
+    return this.supportedPrisonsService.removeSupportedPrison(userToken, prisonId)
   }
 
   private supportedPrisons(allPrisons: Array<Prison>, supportedPrisonCodes: Array<string>): Array<Prison> {


### PR DESCRIPTION
This looks big but it's all just replacing PrisonRegisterService and SupportedPrisonsService with the new facade PrisonService.

Once this is merged it'll be easier to replace all the code that uses `config.supportedPrisons` to filter out unsupported prisons.