### PR TITLE
Update ingress.yaml as prerequisite to switching ingress to new controller.

### DIFF
--- a/helm_deploy/send-legal-mail-to-prisons/templates/ingress.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: check-rule39-mail
@@ -26,11 +26,14 @@ spec:
     http:
       paths:
         - path: /
+          pathType: ImplementationSpecific
           backend:
-            serviceName: send-legal-mail-to-prisons
-            servicePort: http
+            service:
+              name: send-legal-mail-to-prisons
+              port:
+                name: http
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: send-legal-mail-to-prisons
@@ -62,6 +65,9 @@ spec:
       http:
         paths:
             - path: /
+              pathType: ImplementationSpecific
               backend:
-                serviceName: send-legal-mail-to-prisons
-                servicePort: http
+                service:
+                  name: send-legal-mail-to-prisons
+                  port:
+                    name: http


### PR DESCRIPTION
Update ingress.yaml file as mentioned here - https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/apiversion-changes-ingress-k8s-1-22.html as part of prerequisite for switching ingress to the new nginx-ingress-controller v1.2.