### PR TITLE
Switch to new nginx-ingress-controller v1.2

### DIFF
--- a/helm_deploy/send-legal-mail-to-prisons/Chart.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons/Chart.yaml
@@ -5,12 +5,12 @@ name: send-legal-mail-to-prisons
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 1.1.2
+    version: 1.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-service
     alias: gotenberg
-    version: 1.1.2
+    version: 1.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 0.2.7
+    version: 1.1.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/send-legal-mail-to-prisons/templates/ingress.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons/templates/ingress.yaml
@@ -8,7 +8,6 @@ metadata:
   {{- if .Values.allowlist }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.allowlist | quote }}
   {{- end }}
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     external-dns.alpha.kubernetes.io/set-identifier: {{ .Values.ingress.internalSetIdentifier }}
@@ -17,6 +16,7 @@ metadata:
       add_header X-Robots-Tag "noindex, nofollow";
       limit_req_status 429;
 spec:
+  ingressClassName: default
   tls:
   - hosts:
     - {{ .Values.ingress.internalHost }}
@@ -43,7 +43,6 @@ metadata:
   {{- if .Values.allowlist }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.allowlist | quote }}
   {{- end }}
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     external-dns.alpha.kubernetes.io/set-identifier: {{ .Values.ingress.externalSetIdentifier }}
@@ -56,6 +55,7 @@ metadata:
       add_header X-Robots-Tag "noindex, nofollow";
       limit_req_status 429;
 spec:
+  ingressClassName: default
   tls:
     - hosts:
       - {{ .Values.ingress.externalHost }}

--- a/helm_deploy/send-legal-mail-to-prisons/values.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons/values.yaml
@@ -11,6 +11,8 @@ generic-service:
 
   ingress:
     enabled: false
+    v1_2_enabled: true
+    v0_47_enabled: true
 
   livenessProbe:
     httpGet:


### PR DESCRIPTION
Update ingress as mentioned here - https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/Switch-ingress-to-v1-ingress-controller.html to switch to the new nginx-ingress-controller v1.2.