### PR TITLE
Step 2 of switch to the new nginx-ingress-controller v1.2

### DIFF
--- a/helm_deploy/send-legal-mail-to-prisons/Chart.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons/Chart.yaml
@@ -5,12 +5,12 @@ name: send-legal-mail-to-prisons
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 1.1.2
+    version: 1.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-service
     alias: gotenberg
-    version: 1.1.2
+    version: 1.6.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 0.2.7
+    version: 1.1.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/send-legal-mail-to-prisons/templates/ingress_v1_2.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons/templates/ingress_v1_2.yaml
@@ -1,0 +1,73 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: check-rule39-mail-v1-2
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  annotations:
+  {{- if .Values.allowlist }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.allowlist | quote }}
+  {{- end }}
+    nginx.ingress.kubernetes.io/custom-http-errors: "418"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: {{ .Values.ingress.internalSetV12Identifier }}
+    nginx.ingress.kubernetes.io/limit-rpm: "60"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      add_header X-Robots-Tag "noindex, nofollow";
+      limit_req_status 429;
+spec:
+  ingressClassName: default
+  tls:
+  - hosts:
+    - {{ .Values.ingress.internalHost }}
+    secretName: {{ .Values.ingress.internalCertSecret }}
+  rules:
+  - host: {{ .Values.ingress.internalHost }}
+    http:
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: send-legal-mail-to-prisons
+              port:
+                name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: send-legal-mail-to-prisons-v1-2
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  annotations:
+  {{- if .Values.allowlist }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.allowlist | quote }}
+  {{- end }}
+    nginx.ingress.kubernetes.io/custom-http-errors: "418"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: {{ .Values.ingress.externalSetV12Identifier }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      location = / {
+        return 301 $scheme://$host/barcode/find-recipient;
+      }
+    nginx.ingress.kubernetes.io/limit-rpm: "60"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      add_header X-Robots-Tag "noindex, nofollow";
+      limit_req_status 429;
+spec:
+  ingressClassName: default
+  tls:
+    - hosts:
+      - {{ .Values.ingress.externalHost }}
+      secretName: {{ .Values.ingress.externalCertSecret }}
+  rules:
+    - host: {{ .Values.ingress.externalHost }}
+      http:
+        paths:
+            - path: /
+              pathType: ImplementationSpecific
+              backend:
+                service:
+                  name: send-legal-mail-to-prisons
+                  port:
+                    name: http

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -62,4 +62,6 @@ ingress:
   internalHost: check-rule39-mail-dev.prison.service.justice.gov.uk
   externalHost: send-legal-mail-dev.prison.service.justice.gov.uk
   internalSetIdentifier: check-rule39-mail-send-legal-mail-to-prisons-dev-green
+  internalSetV12Identifier: check-rule39-mail-v1-2-send-legal-mail-to-prisons-dev-green
   externalSetIdentifier: send-legal-mail-to-prisons-send-legal-mail-to-prisons-dev-green
+  externalSetV12Identifier: send-legal-mail-to-prisons-v1-2-send-legal-mail-to-prisons-dev-green

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -56,4 +56,6 @@ ingress:
   internalHost: check-rule39-mail-preprod.prison.service.justice.gov.uk
   externalHost: send-legal-mail-preprod.prison.service.justice.gov.uk
   internalSetIdentifier: check-rule39-mail-send-legal-mail-to-prisons-preprod-green
+  internalSetV12Identifier: check-rule39-mail-v1-2-send-legal-mail-to-prisons-preprod-green
   externalSetIdentifier: send-legal-mail-to-prisons-send-legal-mail-to-prisons-preprod-green
+  externalSetV12Identifier: send-legal-mail-to-prisons-v1-2-send-legal-mail-to-prisons-preprod-green

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -19,4 +19,6 @@ ingress:
   internalHost: check-rule39-mail.prison.service.justice.gov.uk
   externalHost: send-legal-mail.prison.service.justice.gov.uk
   internalSetIdentifier: check-rule39-mail-send-legal-mail-to-prisons-prod-green
+  internalSetV12Identifier: check-rule39-mail-v1-2-send-legal-mail-to-prisons-prod-green
   externalSetIdentifier: send-legal-mail-to-prisons-send-legal-mail-to-prisons-prod-green
+  externalSetV12Identifier: send-legal-mail-to-prisons-v1-2-send-legal-mail-to-prisons-prod-green


### PR DESCRIPTION
Step 2 of switch to the new nginx-ingress-controller v1.2. as mentioned here - https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/Switch-ingress-to-v1-ingress-controller.html#step-2-create-a-new-ingress-resource.