### PR TITLE
Speed up Jest with changes from template project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: unit tests
-          command: npm run test
+          command: npm run test:ci
       - store_test_results:
           path: test_results
       - store_artifacts:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-NODE_ENV=dev && node_modules/.bin/lint-staged && node_modules/.bin/tsc && npm test
+NODE_ENV=dev && node_modules/.bin/lint-staged && npm run typecheck && npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,6 @@
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
         "jest-html-reporter": "^3.7.0",
-        "jest-jasmine2": "^29.2.1",
         "jest-junit": "^14.0.1",
         "lint-staged": "^13.0.3",
         "mocha-junit-reporter": "^2.2.0",
@@ -8402,34 +8401,6 @@
       "peerDependencies": {
         "jest": "19.x - 29.x",
         "typescript": "^3.7.x || ^4.3.x"
-      }
-    },
-    "node_modules/jest-jasmine2": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-29.3.1.tgz",
-      "integrity": "sha512-GAsY7aie7YcQc85m/grsOyRGWPDefaJlPYCt2iIPBbA5MMeTbXKrJa4vfMfxJjSmDtbQHxWEoGuUXIA1+bLgvg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/environment": "^29.3.1",
-        "@jest/expect": "^29.3.1",
-        "@jest/source-map": "^29.2.0",
-        "@jest/test-result": "^29.3.1",
-        "@jest/types": "^29.3.1",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.3.1",
-        "jest-matcher-utils": "^29.3.1",
-        "jest-message-util": "^29.3.1",
-        "jest-runtime": "^29.3.1",
-        "jest-snapshot": "^29.3.1",
-        "jest-util": "^29.3.1",
-        "p-limit": "^3.1.0",
-        "pretty-format": "^29.3.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-junit": {
@@ -19415,31 +19386,6 @@
         "sinon": "^9.0.1",
         "strip-ansi": "6.0.1",
         "xmlbuilder": "15.0.0"
-      }
-    },
-    "jest-jasmine2": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-29.3.1.tgz",
-      "integrity": "sha512-GAsY7aie7YcQc85m/grsOyRGWPDefaJlPYCt2iIPBbA5MMeTbXKrJa4vfMfxJjSmDtbQHxWEoGuUXIA1+bLgvg==",
-      "dev": true,
-      "requires": {
-        "@jest/environment": "^29.3.1",
-        "@jest/expect": "^29.3.1",
-        "@jest/source-map": "^29.2.0",
-        "@jest/test-result": "^29.3.1",
-        "@jest/types": "^29.3.1",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.3.1",
-        "jest-matcher-utils": "^29.3.1",
-        "jest-message-util": "^29.3.1",
-        "jest-runtime": "^29.3.1",
-        "jest-snapshot": "^29.3.1",
-        "jest-util": "^29.3.1",
-        "p-limit": "^3.1.0",
-        "pretty-format": "^29.3.1"
       }
     },
     "jest-junit": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "record-build-info": "node ./bin/record-build-info",
     "lint": "eslint . --cache --max-warnings 0",
     "typecheck": "tsc && tsc -p integration_tests",
-    "test": "jest --runInBand --detectOpenHandles",
+    "test": "jest --coverage",
+    "test:ci": "jest --runInBand --coverage",
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false --env $(grep ONE_TIME_CODE_AUTH_ENABLED feature.env)",
     "int-test-ui": "cypress open --env $(grep ONE_TIME_CODE_AUTH_ENABLED feature.env)",
@@ -33,7 +34,14 @@
   },
   "jest": {
     "preset": "ts-jest",
-    "collectCoverage": true,
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "isolatedModules": true
+        }
+      ]
+    },
     "collectCoverageFrom": [
       "server/**/*.{ts,js,jsx,mjs}"
     ],
@@ -63,8 +71,7 @@
       "json",
       "node",
       "ts"
-    ],
-    "testRunner": "jest-jasmine2"
+    ]
   },
   "nodemonConfig": {
     "ignore": [
@@ -166,7 +173,6 @@
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "jest-html-reporter": "^3.7.0",
-    "jest-jasmine2": "^29.2.1",
     "jest-junit": "^14.0.1",
     "lint-staged": "^13.0.3",
     "mocha-junit-reporter": "^2.2.0",

--- a/server/data/healthCheck.test.ts
+++ b/server/data/healthCheck.test.ts
@@ -15,6 +15,7 @@ describe('Service healthcheck', () => {
   })
 
   afterEach(() => {
+    nock.abortPendingRequests()
     nock.cleanAll()
   })
 

--- a/server/services/cjsm/CjsmService.test.ts
+++ b/server/services/cjsm/CjsmService.test.ts
@@ -30,7 +30,7 @@ describe('CjsmService', () => {
       expect(userDetails).toStrictEqual(expectedResponse)
     })
 
-    it('should return not found', async done => {
+    it('should return not found', () => {
       const expectedError = {
         status: 404,
         errorCode: {
@@ -40,9 +40,8 @@ describe('CjsmService', () => {
       }
       mockedSendLegalMailApi.get('/cjsm/user/me').reply(404, expectedError)
 
-      cjsmService.getUserDetails('some-token').catch(error => {
-        expect(JSON.parse(error.text)).toStrictEqual(expectedError)
-        done()
+      return cjsmService.getUserDetails('some-token').catch(async error => {
+        await expect(JSON.parse(error.text)).toStrictEqual(expectedError)
       })
     })
   })


### PR DESCRIPTION
* Bring over recent changes from the template project to speed up Jest.
* Remove custom test runner, `jest-jasmine2` - which looks to have been added early in the project to [work around a bug](https://github.com/ministryofjustice/send-legal-mail-to-prisons/pull/222#discussion_r821771900) but is no longer needed.
* Tweak a few tests to prevent warnings about open handles being left on test runs

Performance improvements (running locally):

**Before**
```bash
Test Suites: 109 passed, 109 total
Tests:       598 passed, 598 total
Snapshots:   0 total
Time:        28.109 s, estimated 35 s
```

**After**
```bash
Test Suites: 109 passed, 109 total
Tests:       598 passed, 598 total
Snapshots:   0 total
Time:        7.582 s, estimated 14 s
```