### PR TITLE
Revert "Pin npm to 9.2.0 based on Tom's suggestion as a fix for build issues."

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - checkout
       - run:
           name: Update npm
-          command: 'npm install -g npm@9.2.0'
+          command: 'npm install -g npm@latest'
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:


### PR DESCRIPTION
Reverts ministryofjustice/send-legal-mail-to-prisons#384

Issue with `npm` that required us to pin the version now looks to be fixed (https://github.com/npm/cli/releases/tag/v9.3.1)