### PR TITLE
SLM-270: Fix smoke tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
       - hmpps/k8s_setup
       - run:
           name: Install jq
-          command: apt install -y jq
+          command: apt-get update && apt-get install -y jq
       - run:
           name: Run smoke tests in << parameters.env >>
           command: |

--- a/smoke_tests/cypress.config.ts
+++ b/smoke_tests/cypress.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
         getSmokeTestBarcode: state.getSmokeTestBarcode,
       })
     },
-    baseUrl: 'http://localhost:3000',
     excludeSpecPattern: '**/!(*.cy).ts',
     specPattern: 'smoke/**/*.cy.{js,jsx,ts,tsx}',
     supportFile: 'support/index.ts',

--- a/smoke_tests/run-smoke-test.sh
+++ b/smoke_tests/run-smoke-test.sh
@@ -43,7 +43,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 DIR=/tmp/slm-smoke-test-$ENV
-rmdir $DIR 2>/dev/null
+rm -rfv $DIR 2>/dev/null
 mkdir -p $DIR
 cp -r ../integration_tests/* $DIR
 cp cypress.config.ts package.json reporter-config.json run-smoke-test.sh $DIR


### PR DESCRIPTION
* Fix installation of `jq` dependency that was failing
* Remove unnecessary `baseUrl` config that was incorrectly overriding CI config
* Fix error in `run-smoke-tests.sh` that stopped build directory being deleted locally