### PR TITLE
Remove expectHelpdeskLink from pages on new staff UI 

### DIFF
--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -3,7 +3,7 @@ import ScanBarcodePage from './scan/scanBarcode'
 
 export default class IndexPage extends Page {
   constructor() {
-    super('index-page')
+    super('index-page', { expectHelpdeskLink: false })
   }
 
   containsTile(tileTitle: string): IndexPage {

--- a/integration_tests/pages/scan/manualBarcodeEntry.ts
+++ b/integration_tests/pages/scan/manualBarcodeEntry.ts
@@ -5,7 +5,7 @@ import barcodes from '../../mockApis/barcodes'
 
 export default class ManualBarcodeEntryPage extends Page {
   constructor() {
-    super('manually-enter-barcode')
+    super('manually-enter-barcode', { expectHelpdeskLink: false })
   }
 
   setBarcode = (value: string): ManualBarcodeEntryPage => {

--- a/integration_tests/pages/scan/scanAnotherBarcode.ts
+++ b/integration_tests/pages/scan/scanAnotherBarcode.ts
@@ -7,7 +7,7 @@ import ManualBarcodeEntryPage from './manualBarcodeEntry'
 
 export default class ScanAnotherBarcodePage extends Page {
   constructor() {
-    super('scan-another-barcode')
+    super('scan-another-barcode', { expectHelpdeskLink: false })
     this.barcodeFieldIsFocussed()
   }
 

--- a/integration_tests/pages/scan/scanBarcode.ts
+++ b/integration_tests/pages/scan/scanBarcode.ts
@@ -5,7 +5,7 @@ import ManualBarcodeEntryPage from './manualBarcodeEntry'
 
 export default class ScanBarcodePage extends Page {
   constructor() {
-    super('scan-barcode')
+    super('scan-barcode', { expectHelpdeskLink: false })
     this.barcodeFieldIsFocussed()
   }
 

--- a/integration_tests/pages/scan/scanBarcodeResult.ts
+++ b/integration_tests/pages/scan/scanBarcodeResult.ts
@@ -4,7 +4,7 @@ import ScanAnotherBarcodePage from './scanAnotherBarcode'
 
 export default class ScanBarcodeResultPage extends Page {
   constructor() {
-    super('scan-barcode-result')
+    super('scan-barcode-result', { expectHelpdeskLink: false })
   }
 
   clickFurtherChecksNecessary = (): ScanBarcodeResultPage => {


### PR DESCRIPTION
Set expectHelpdeskLink to false on pages used by new staff UI as smoke tests fail since helpdesk links are no longer available on staff UI.