### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/send-legal-mail-to-prisons/Chart.yaml
+++ b/helm_deploy/send-legal-mail-to-prisons/Chart.yaml
@@ -5,11 +5,11 @@ name: send-legal-mail-to-prisons
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.8.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-service
     alias: gotenberg
-    version: 2.8.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -23,29 +23,9 @@ generic-service:
 
   allowlist:
     moj-official-tgw-prod: 51.149.250.0/24
-    circleci-1: 3.228.39.90/32
-    circleci-2: 18.213.67.41/32
-    circleci-3: 34.194.94.201/32
-    circleci-4: 34.194.144.202/32
-    circleci-5: 34.197.6.234/32
-    circleci-6: 35.169.17.173/32
-    circleci-7: 35.174.253.146/32
-    circleci-8: 52.3.128.216/32
-    circleci-9: 52.4.195.249/32
-    circleci-10: 52.5.58.121/32
-    circleci-11: 52.21.153.129/32
-    circleci-12: 52.72.72.233/32
-    circleci-13: 54.92.235.88/32
-    circleci-14: 54.161.182.76/32
-    circleci-15: 54.164.161.41/32
-    circleci-16: 54.166.105.113/32
-    circleci-17: 54.167.72.230/32
-    circleci-18: 54.172.26.132/32
-    circleci-19: 54.205.138.102/32
-    circleci-20: 54.208.72.234/32
-    circleci-21: 54.209.115.53/32
     groups:
       - internal
+      - circleci
 
 gotenberg:
   replicaCount: 2

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in send-legal-mail-to-prisons/values.yaml
 
 generic-service:
@@ -23,38 +22,30 @@ generic-service:
       APP_SMOKETEST_LSJSECRET: "APP_SMOKETEST_LSJSECRET"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    moj-official-tgw-prod: "51.149.250.0/24"
-    # Circle CI allowed for smoke tests. IP ranges defined here: https://circleci.com/docs/2.0/ip-ranges#list-of-ip-address-ranges
-    circle-ci-1: "3.228.39.90"
-    circle-ci-2: "18.213.67.41"
-    circle-ci-3: "34.194.94.201"
-    circle-ci-4: "34.194.144.202"
-    circle-ci-5: "34.197.6.234"
-    circle-ci-6: "35.169.17.173"
-    circle-ci-7: "35.174.253.146"
-    circle-ci-8: "52.3.128.216"
-    circle-ci-9: "52.4.195.249"
-    circle-ci-10: "52.5.58.121"
-    circle-ci-11: "52.21.153.129"
-    circle-ci-12: "52.72.72.233"
-    circle-ci-13: "54.92.235.88"
-    circle-ci-14: "54.161.182.76"
-    circle-ci-15: "54.164.161.41"
-    circle-ci-16: "54.166.105.113"
-    circle-ci-17: "54.167.72.230"
-    circle-ci-18: "54.172.26.132"
-    circle-ci-19: "54.205.138.102"
-    circle-ci-20: "54.208.72.234"
-    circle-ci-21: "54.209.115.53"
-
+    moj-official-tgw-prod: 51.149.250.0/24
+    circleci-1: 3.228.39.90/32
+    circleci-2: 18.213.67.41/32
+    circleci-3: 34.194.94.201/32
+    circleci-4: 34.194.144.202/32
+    circleci-5: 34.197.6.234/32
+    circleci-6: 35.169.17.173/32
+    circleci-7: 35.174.253.146/32
+    circleci-8: 52.3.128.216/32
+    circleci-9: 52.4.195.249/32
+    circleci-10: 52.5.58.121/32
+    circleci-11: 52.21.153.129/32
+    circleci-12: 52.72.72.233/32
+    circleci-13: 54.92.235.88/32
+    circleci-14: 54.161.182.76/32
+    circleci-15: 54.164.161.41/32
+    circleci-16: 54.166.105.113/32
+    circleci-17: 54.167.72.230/32
+    circleci-18: 54.172.26.132/32
+    circleci-19: 54.205.138.102/32
+    circleci-20: 54.208.72.234/32
+    circleci-21: 54.209.115.53/32
+    groups:
+      - internal
 
 gotenberg:
   replicaCount: 2

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in send-legal-mail-to-prisons/values.yaml
 
 generic-service:
@@ -21,37 +20,30 @@ generic-service:
       APP_SMOKETEST_LSJSECRET: "APP_SMOKETEST_LSJSECRET"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    moj-official-tgw-prod: "51.149.250.0/24"
-    # Circle CI allowed for smoke tests. IP ranges defined here: https://circleci.com/docs/2.0/ip-ranges#list-of-ip-address-ranges
-    circle-ci-1: "3.228.39.90"
-    circle-ci-2: "18.213.67.41"
-    circle-ci-3: "34.194.94.201"
-    circle-ci-4: "34.194.144.202"
-    circle-ci-5: "34.197.6.234"
-    circle-ci-6: "35.169.17.173"
-    circle-ci-7: "35.174.253.146"
-    circle-ci-8: "52.3.128.216"
-    circle-ci-9: "52.4.195.249"
-    circle-ci-10: "52.5.58.121"
-    circle-ci-11: "52.21.153.129"
-    circle-ci-12: "52.72.72.233"
-    circle-ci-13: "54.92.235.88"
-    circle-ci-14: "54.161.182.76"
-    circle-ci-15: "54.164.161.41"
-    circle-ci-16: "54.166.105.113"
-    circle-ci-17: "54.167.72.230"
-    circle-ci-18: "54.172.26.132"
-    circle-ci-19: "54.205.138.102"
-    circle-ci-20: "54.208.72.234"
-    circle-ci-21: "54.209.115.53"
+    moj-official-tgw-prod: 51.149.250.0/24
+    circleci-1: 3.228.39.90/32
+    circleci-2: 18.213.67.41/32
+    circleci-3: 34.194.94.201/32
+    circleci-4: 34.194.144.202/32
+    circleci-5: 34.197.6.234/32
+    circleci-6: 35.169.17.173/32
+    circleci-7: 35.174.253.146/32
+    circleci-8: 52.3.128.216/32
+    circleci-9: 52.4.195.249/32
+    circleci-10: 52.5.58.121/32
+    circleci-11: 52.21.153.129/32
+    circleci-12: 52.72.72.233/32
+    circleci-13: 54.92.235.88/32
+    circleci-14: 54.161.182.76/32
+    circleci-15: 54.164.161.41/32
+    circleci-16: 54.166.105.113/32
+    circleci-17: 54.167.72.230/32
+    circleci-18: 54.172.26.132/32
+    circleci-19: 54.205.138.102/32
+    circleci-20: 54.208.72.234/32
+    circleci-21: 54.209.115.53/32
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   alertSeverity: send-legal-mail-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,29 +21,9 @@ generic-service:
 
   allowlist:
     moj-official-tgw-prod: 51.149.250.0/24
-    circleci-1: 3.228.39.90/32
-    circleci-2: 18.213.67.41/32
-    circleci-3: 34.194.94.201/32
-    circleci-4: 34.194.144.202/32
-    circleci-5: 34.197.6.234/32
-    circleci-6: 35.169.17.173/32
-    circleci-7: 35.174.253.146/32
-    circleci-8: 52.3.128.216/32
-    circleci-9: 52.4.195.249/32
-    circleci-10: 52.5.58.121/32
-    circleci-11: 52.21.153.129/32
-    circleci-12: 52.72.72.233/32
-    circleci-13: 54.92.235.88/32
-    circleci-14: 54.161.182.76/32
-    circleci-15: 54.164.161.41/32
-    circleci-16: 54.166.105.113/32
-    circleci-17: 54.167.72.230/32
-    circleci-18: 54.172.26.132/32
-    circleci-19: 54.205.138.102/32
-    circleci-20: 54.208.72.234/32
-    circleci-21: 54.209.115.53/32
     groups:
       - internal
+      - circleci
 
 generic-prometheus-alerts:
   alertSeverity: send-legal-mail-alerts


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

2 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/values-dev.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `30 => 22 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

## Allowlist: helm_deploy/values-preprod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `30 => 22 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  
