### PR TITLE
remove smoke tests temporarily since we haven't got a fix for the cer…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ feature_branch: &feature_branch
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7
+  hmpps: ministryofjustice/hmpps@8
   slack: circleci/slack@4.12.1
 
 parameters:
@@ -216,6 +216,11 @@ workflows:
           context: hmpps-common-vars
           requires:
             - request-dev-preview-approval
+      #- run_smoke_test:
+          #name: smoke_test_dev_preview
+          #env: dev
+          #requires:
+            #- deploy_dev_preview
 
       - hmpps/deploy_env:
           <<: *main_branch
@@ -227,11 +232,11 @@ workflows:
             - unit_test
             - integration_test
             - build_docker
-      - run_smoke_test:
-          name: smoke_test_dev
-          env: dev
-          requires:
-            - deploy_dev
+      #- run_smoke_test:
+          #name: smoke_test_dev
+          #env: dev
+          #requires:
+            #- deploy_dev
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"
@@ -239,19 +244,19 @@ workflows:
             - hmpps-common-vars
             - send-legal-mail-to-prisons-preprod
           requires:
-            - smoke_test_dev
-      - run_smoke_test:
-          name: smoke_test_preprod
-          env: preprod
-          requires:
-            - deploy_preprod
-          context:
-            - hmpps-common-vars
-            - send-legal-mail-to-prisons-preprod
+            - deploy_dev
+      #- run_smoke_test:
+          #name: smoke_test_preprod
+          #env: preprod
+          #requires:
+            #- deploy_preprod
+          #context:
+            #- hmpps-common-vars
+            #- send-legal-mail-to-prisons-preprod
       - request-prod-approval:
           type: approval
           requires:
-            - smoke_test_preprod
+            - deploy_preprod
       - hmpps/deploy_env:
           name: deploy_prod
           env: "prod"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ FROM base as build
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available
 
+RUN apt-get update && \
+    apt-get install -y curl
+
 COPY package*.json ./
 RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit
 


### PR DESCRIPTION
remove smoke tests temporarily since we haven't got a fix for the certificate issue yet. Brief detail about the issue - 

Since the last few days we have been getting this error while trying to run the smoke tests. This is primarily down to the apt-get update failing to update the certs. Tried multiple options however but seems to fail every time. Also updated the dockerfile from bullseye to bookworm but still the same issue. So disabling the smoke tests till we get around this issue. Hopefully Google will update the certs post which it starts running again as earlier - 

Example - 
https://app.circleci.com/pipelines/github/ministryofjustice/send-legal-mail-to-prisons/1992/workflows/df2d6d09-6383-4ff9-8259-a2cb3deda3b8/jobs/9233